### PR TITLE
Rename RPC metrics

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,8 +174,8 @@ func TestConfigWithRPCMetrics(t *testing.T) {
 
 	testutils.AssertCounterMetrics(t, metrics,
 		testutils.ExpectedMetric{
-			Name:  "jaeger.requests",
-			Tags:  map[string]string{"component": "jaeger", "operation": "test", "error": "false"},
+			Name:  "jaeger.operation",
+			Tags:  map[string]string{"component": "jaeger", "operation": "test", "result": "ok"},
 			Value: 1,
 		},
 	)

--- a/rpcmetrics/metrics.go
+++ b/rpcmetrics/metrics.go
@@ -34,29 +34,29 @@ const (
 // Metrics is a collection of metrics for an operation describing
 // throughput, success, errors, and performance.
 type Metrics struct {
-	// RequestCountSuccess is a counter of the total number of successes.
-	RequestCountSuccess metrics.Counter `metric:"requests" tags:"error=false"`
+	// OperationCountSuccess is a counter of the total number of successes.
+	OperationCountSuccess metrics.Counter `metric:"operation" tags:"result=ok"`
 
-	// RequestCountFailures is a counter of the number of times any failure has been observed.
-	RequestCountFailures metrics.Counter `metric:"requests" tags:"error=true"`
+	// OperationCountFailures is a counter of the number of times any failure has been observed.
+	OperationCountFailures metrics.Counter `metric:"operation" tags:"result=err"`
 
-	// RequestLatencySuccess is a latency histogram of succesful requests.
-	RequestLatencySuccess metrics.Timer `metric:"request_latency" tags:"error=false"`
+	// OperationLatencySuccess is a latency histogram of successful requests.
+	OperationLatencySuccess metrics.Timer `metric:"latency" tags:"result=ok"`
 
-	// RequestLatencyFailures is a latency histogram of failed requests.
-	RequestLatencyFailures metrics.Timer `metric:"request_latency" tags:"error=true"`
+	// OperationLatencyFailures is a latency histogram of failed requests.
+	OperationLatencyFailures metrics.Timer `metric:"latency" tags:"result=err"`
 
 	// HTTPStatusCode2xx is a counter of the total number of requests with HTTP status code 200-299
-	HTTPStatusCode2xx metrics.Counter `metric:"http_requests" tags:"status_code=2xx"`
+	HTTPStatusCode2xx metrics.Counter `metric:"operation" tags:"result=ok,transport=http,status_code=2xx"`
 
 	// HTTPStatusCode3xx is a counter of the total number of requests with HTTP status code 300-399
-	HTTPStatusCode3xx metrics.Counter `metric:"http_requests" tags:"status_code=3xx"`
+	HTTPStatusCode3xx metrics.Counter `metric:"operation" tags:"result=ok,transport=http,status_code=3xx"`
 
 	// HTTPStatusCode4xx is a counter of the total number of requests with HTTP status code 400-499
-	HTTPStatusCode4xx metrics.Counter `metric:"http_requests" tags:"status_code=4xx"`
+	HTTPStatusCode4xx metrics.Counter `metric:"operation" tags:"result=err,transport=http,status_code=4xx"`
 
 	// HTTPStatusCode5xx is a counter of the total number of requests with HTTP status code 500-599
-	HTTPStatusCode5xx metrics.Counter `metric:"http_requests" tags:"status_code=5xx"`
+	HTTPStatusCode5xx metrics.Counter `metric:"operation" tags:"result=err,transport=http,status_code=5xx"`
 }
 
 func (m *Metrics) recordHTTPStatusCode(statusCode uint16) {

--- a/rpcmetrics/metrics_test.go
+++ b/rpcmetrics/metrics_test.go
@@ -56,12 +56,12 @@ func TestMetricsByOperation(t *testing.T) {
 	m5 := mbe.get("overflow2")
 
 	for _, m := range []*Metrics{m1, m2, m2a, m3, m4, m5} {
-		m.RequestCountSuccess.Inc(1)
+		m.OperationCountSuccess.Inc(1)
 	}
 
 	testutils.AssertCounterMetrics(t, met,
-		testutils.ExpectedMetric{Name: "requests", Tags: operationTags("abc1", "error", "false"), Value: 3},
-		testutils.ExpectedMetric{Name: "requests", Tags: operationTags("abc3", "error", "false"), Value: 1},
-		testutils.ExpectedMetric{Name: "requests", Tags: operationTags("other", "error", "false"), Value: 2},
+		testutils.ExpectedMetric{Name: "operation", Tags: operationTags("abc1", "result", "ok"), Value: 3},
+		testutils.ExpectedMetric{Name: "operation", Tags: operationTags("abc3", "result", "ok"), Value: 1},
+		testutils.ExpectedMetric{Name: "operation", Tags: operationTags("other", "result", "ok"), Value: 2},
 	)
 }

--- a/rpcmetrics/observer.go
+++ b/rpcmetrics/observer.go
@@ -152,14 +152,21 @@ func (so *SpanObserver) OnFinish(options opentracing.FinishOptions) {
 
 	mets := so.metricsByOperation.get(so.operationName)
 	latency := options.FinishTime.Sub(so.startTime)
+	isHTTPOperation := so.httpStatusCode != 0
 	if so.err {
-		mets.RequestCountFailures.Inc(1)
-		mets.RequestLatencyFailures.Record(latency)
+		if !isHTTPOperation {
+			mets.OperationCountFailures.Inc(1)
+		}
+		mets.OperationLatencyFailures.Record(latency)
 	} else {
-		mets.RequestCountSuccess.Inc(1)
-		mets.RequestLatencySuccess.Record(latency)
+		if !isHTTPOperation {
+			mets.OperationCountSuccess.Inc(1)
+		}
+		mets.OperationLatencySuccess.Record(latency)
 	}
-	mets.recordHTTPStatusCode(so.httpStatusCode)
+	if isHTTPOperation {
+		mets.recordHTTPStatusCode(so.httpStatusCode)
+	}
 }
 
 // OnSetOperationName records new operation name.


### PR DESCRIPTION
I renamed the metrics to be not transport and request specific. However, it has become a bit clunky: ie jaeger.operation|result=ok|operation=GET