### PR TITLE
Zipkin HTTP reporter doesn't lose batches on server errors

### DIFF
--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -121,11 +121,8 @@ func (c *HTTPTransport) Flush() (int, error) {
 		return 0, nil
 	}
 	err := c.send(c.batch)
-	if err != nil {
-		return 0, err
-	}
 	c.batch = c.batch[:0]
-	return count, nil
+	return count, err
 }
 
 // Close implements Transport.

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -187,6 +187,6 @@ func TestHTTP404(t *testing.T) {
 	span.Finish()
 
 	c, err := sender.Append(span.(*jaeger.Span))
-	assert.Equal(t, 0, c)
+	assert.Equal(t, 1, c)
 	assert.EqualError(t, err, "Unsuccessful HTTP status: 404, Body: 404 page not found\n")
 }

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -176,3 +176,17 @@ func newHTTPServer(t *testing.T) *httpServer {
 
 	return server
 }
+
+func TestHTTP404(t *testing.T) {
+	sender, err := NewHTTPTransport("http://localhost:10000/api/maps", HTTPBatchSize(1))
+	require.NoError(t, err)
+
+	tracer, _ := jaeger.NewTracer("DOOP", jaeger.NewConstSampler(true), jaeger.NewNullReporter())
+
+	span := tracer.StartSpan("root")
+	span.Finish()
+
+	c, err := sender.Append(span.(*jaeger.Span))
+	assert.Equal(t, 0, c)
+	assert.EqualError(t, err, "Unsuccessful HTTP status: 404, Body: 404 page not found\n")
+}


### PR DESCRIPTION
- Also report errors for http response code >= 400