### PR TITLE
Add option for consistent high trace ID

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -136,7 +136,11 @@ func NewTracer(
 		t.logger.Error("Unable to determine this host's IP address: " + err.Error())
 	}
 
-	if !t.options.gen128Bit && t.options.highTraceIDGenerator != nil {
+	if t.options.gen128Bit {
+		if t.options.highTraceIDGenerator == nil {
+			t.options.highTraceIDGenerator = t.randomNumber
+		}
+	} else if t.options.highTraceIDGenerator != nil {
 		t.logger.Error("Overriding high trace ID generator but not generating " +
 			"128 bit trace IDs, consider enabling the \"Gen128Bit\" option")
 	}
@@ -212,11 +216,7 @@ func (t *Tracer) startSpanWithOptions(
 		newTrace = true
 		ctx.traceID.Low = t.randomID()
 		if t.options.gen128Bit {
-			if t.options.highTraceIDGenerator != nil {
-				ctx.traceID.High = t.options.highTraceIDGenerator()
-			} else {
-				ctx.traceID.High = t.randomID()
-			}
+			ctx.traceID.High = t.options.highTraceIDGenerator()
 		}
 		ctx.spanID = SpanID(ctx.traceID.Low)
 		ctx.parentID = 0

--- a/tracer.go
+++ b/tracer.go
@@ -62,7 +62,6 @@ type Tracer struct {
 
 	baggageRestrictionManager baggage.RestrictionManager
 	baggageSetter             *baggageSetter
-	serviceNameHash           uint64
 }
 
 // NewTracer creates Tracer implementation that reports tracing to Jaeger.

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -121,9 +121,9 @@ func (tracerOptions) Gen128Bit(gen128Bit bool) TracerOption {
 	}
 }
 
-func (tracerOptions) ConsistentHighTraceID(consistentHighTraceID bool) TracerOption {
+func (tracerOptions) HighTraceIDGenerator(highTraceIDGenerator func() uint64) TracerOption {
 	return func(tracer *Tracer) {
-		tracer.options.consistentHighTraceID = consistentHighTraceID
+		tracer.options.highTraceIDGenerator = highTraceIDGenerator
 	}
 }
 

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -121,6 +121,12 @@ func (tracerOptions) Gen128Bit(gen128Bit bool) TracerOption {
 	}
 }
 
+func (tracerOptions) ConsistentHighTraceID(consistentHighTraceID bool) TracerOption {
+	return func(tracer *Tracer) {
+		tracer.options.consistentHighTraceID = consistentHighTraceID
+	}
+}
+
 func (tracerOptions) ZipkinSharedRPCSpan(zipkinSharedRPCSpan bool) TracerOption {
 	return func(tracer *Tracer) {
 		tracer.options.zipkinSharedRPCSpan = zipkinSharedRPCSpan

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -335,6 +335,9 @@ func TestHighTraceIDGenerator(t *testing.T) {
 	assert.True(t, calledGenerator)
 }
 
+// TODO: Remove mockLogger in favor of testutils/logger.go once it is refactored
+// from jaeger into jaeger-lib.
+
 type mockLogger struct {
 	msg string
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -317,6 +317,24 @@ func TestGen128Bit(t *testing.T) {
 	assert.True(t, traceID.Low != 0)
 }
 
+func TestConsistentHighTraceID(t *testing.T) {
+	tracer, tc := NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.ConsistentHighTraceID(true))
+	defer tc.Close()
+
+	span1 := tracer.StartSpan("test", opentracing.ChildOf(emptyContext))
+	defer span1.Finish()
+	traceID1 := span1.Context().(SpanContext).TraceID()
+	assert.True(t, traceID1.High != 0)
+	assert.True(t, traceID1.Low != 0)
+
+	span2 := tracer.StartSpan("test", opentracing.ChildOf(emptyContext))
+	defer span2.Finish()
+	traceID2 := span2.Context().(SpanContext).TraceID()
+	assert.True(t, traceID2.High != 0)
+	assert.True(t, traceID2.Low != 0)
+	assert.Equal(t, traceID1.High, traceID2.High)
+}
+
 func TestZipkinSharedRPCSpan(t *testing.T) {
 	tracer, tc := NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.ZipkinSharedRPCSpan(false))
 


### PR DESCRIPTION
Allow high 64 bits of trace ID to be set to the first 64 bits of SHA256 of service name. This is a quick way to identify the originator of a given trace.