### PR TITLE
make tracer.randomID recursive to ensure non-zero

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -376,7 +376,7 @@ func (t *Tracer) reportSpan(sp *Span) {
 func (t *Tracer) randomID() uint64 {
 	val := t.randomNumber()
 	for val == 0 {
-		val = t.randomNumber()
+		val = t.randomID()
 	}
 	return val
 }


### PR DESCRIPTION
The way it is written, two 0 results in a row would cause problems.

Signed-off-by: Derek Perkins derek@derekperkins.com