### PR TITLE
Fix undefined switch logic when reporter is closed

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -195,6 +195,7 @@ func NewRemoteReporter(sender Transport, opts ...ReporterOption) Reporter {
 		closed:          make(chan interface{}),
 		queue:           make(chan *Span, options.queueSize),
 	}
+	println("start processQueue")
 	go reporter.processQueue()
 	return reporter
 }
@@ -234,10 +235,12 @@ func (r *remoteReporter) Close() {
 // Buffer also gets flushed automatically every batchFlushInterval seconds, just in case the tracer stopped
 // reporting new spans.
 func (r *remoteReporter) processQueue() {
+	println("processQueue")
 	timer := time.NewTicker(r.bufferFlushInterval)
 	for {
 		select {
 		case span := <-r.queue:
+			println("we got a span")
 			atomic.AddInt64(&r.queueLength, -1)
 			if flushed, err := r.sender.Append(span); err != nil {
 				r.metrics.ReporterFailure.Inc(int64(flushed))

--- a/reporter.go
+++ b/reporter.go
@@ -195,7 +195,6 @@ func NewRemoteReporter(sender Transport, opts ...ReporterOption) Reporter {
 		closed:          make(chan interface{}),
 		queue:           make(chan *Span, options.queueSize),
 	}
-	println("start processQueue")
 	go reporter.processQueue()
 	return reporter
 }
@@ -203,7 +202,6 @@ func NewRemoteReporter(sender Transport, opts ...ReporterOption) Reporter {
 // Report implements Report() method of Reporter.
 // It passes the span to a background go-routine for submission to Jaeger.
 func (r *remoteReporter) Report(span *Span) {
-	println("report span")
 	select {
 	// This path will be triggered whenever request to report a span
 	// comes, while reporter was already closed
@@ -236,12 +234,10 @@ func (r *remoteReporter) Close() {
 // Buffer also gets flushed automatically every batchFlushInterval seconds, just in case the tracer stopped
 // reporting new spans.
 func (r *remoteReporter) processQueue() {
-	println("processQueue")
 	timer := time.NewTicker(r.bufferFlushInterval)
 	for {
 		select {
 		case span := <-r.queue:
-			println("we got a span")
 			atomic.AddInt64(&r.queueLength, -1)
 			if flushed, err := r.sender.Append(span); err != nil {
 				r.metrics.ReporterFailure.Inc(int64(flushed))

--- a/reporter.go
+++ b/reporter.go
@@ -203,6 +203,7 @@ func NewRemoteReporter(sender Transport, opts ...ReporterOption) Reporter {
 // Report implements Report() method of Reporter.
 // It passes the span to a background go-routine for submission to Jaeger.
 func (r *remoteReporter) Report(span *Span) {
+	println("report span")
 	select {
 	// This path will be triggered whenever request to report a span
 	// comes, while reporter was already closed

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -201,7 +201,12 @@ func testRemoteReporter(
 	span.Finish()
 	closer.Close() // close the tracer, which also closes and flushes the reporter
 	// however, in case of UDP reporter it's fire and forget, so we need to wait a bit
-	time.Sleep(5 * time.Millisecond)
+	for i := 0; i < 1000; i++ {
+		if batches := getBatches(); len(batches) == 1 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
 
 	batches := getBatches()
 	require.Equal(t, 1, len(batches))

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -194,14 +194,13 @@ func testRemoteReporter(
 		NewConstSampler(true),
 		reporter,
 		TracerOptions.Metrics(metrics))
+	defer closer.Close()
 
 	span := tracer.StartSpan("leela")
 	ext.SpanKindRPCClient.Set(span)
 	ext.PeerService.Set(span, "downstream")
 	span.Finish()
-	closer.Close() // close the tracer, which also closes and flushes the reporter
-	// however, in case of UDP reporter it's fire and forget, so we need to wait a bit
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 5000; i++ {
 		if batches := getBatches(); len(batches) == 1 {
 			break
 		}

--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -104,7 +104,6 @@ func NewHTTPTransport(url string, options ...HTTPOption) (*HTTPTransport, error)
 
 // Append implements Transport.
 func (c *HTTPTransport) Append(span *jaeger.Span) (int, error) {
-	println("append")
 	zSpan := jaeger.BuildZipkinThrift(span)
 	c.batch = append(c.batch, zSpan)
 	if len(c.batch) >= c.batchSize {
@@ -120,10 +119,6 @@ func (c *HTTPTransport) Flush() (int, error) {
 		return 0, nil
 	}
 	err := c.send(c.batch)
-	println("we are here")
-	if err != nil {
-		println(err.Error())
-	}
 	c.batch = c.batch[:0]
 	return count, err
 }

--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -104,6 +104,7 @@ func NewHTTPTransport(url string, options ...HTTPOption) (*HTTPTransport, error)
 
 // Append implements Transport.
 func (c *HTTPTransport) Append(span *jaeger.Span) (int, error) {
+	println("append")
 	zSpan := jaeger.BuildZipkinThrift(span)
 	c.batch = append(c.batch, zSpan)
 	if len(c.batch) >= c.batchSize {

--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -119,6 +119,10 @@ func (c *HTTPTransport) Flush() (int, error) {
 		return 0, nil
 	}
 	err := c.send(c.batch)
+	println("we are here")
+	if err != nil {
+		println(err.Error())
+	}
 	c.batch = c.batch[:0]
 	return count, err
 }

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -57,11 +57,10 @@ func TestHttpTransport(t *testing.T) {
 		jaeger.NewConstSampler(true),
 		jaeger.NewRemoteReporter(sender),
 	)
+	defer closer.Close()
 
 	span := tracer.StartSpan("root")
 	span.Finish()
-
-	closer.Close()
 
 	// Need to yield to the select loop to accept the send request, and then
 	// yield again to the send operation to write to the socket. I think the

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -63,7 +63,7 @@ func TestHttpTransport(t *testing.T) {
 	// yield again to the send operation to write to the socket. I think the
 	// best way to do that is just give it some time.
 
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for {
 		if time.Now().After(deadline) {
 			t.Fatal("never received a span")

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -45,7 +45,11 @@ func TestHttpTransport(t *testing.T) {
 	server := newHTTPServer(t)
 	httpUsername := "Aphex"
 	httpPassword := "Twin"
-	sender, err := NewHTTPTransport("http://localhost:10000/api/v1/spans", HTTPBasicAuth(httpUsername, httpPassword))
+	sender, err := NewHTTPTransport(
+		"http://localhost:10000/api/v1/spans",
+		HTTPBatchSize(1),
+		HTTPBasicAuth(httpUsername, httpPassword),
+	)
 	require.NoError(t, err)
 
 	tracer, closer := jaeger.NewTracer(
@@ -63,7 +67,7 @@ func TestHttpTransport(t *testing.T) {
 	// yield again to the send operation to write to the socket. I think the
 	// best way to do that is just give it some time.
 
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(2 * time.Second)
 	for {
 		if time.Now().After(deadline) {
 			t.Fatal("never received a span")


### PR DESCRIPTION
There's a race condition in remoteReporter.Report() where if both r.closed and r.queue channels are closed, the switch stmt will pick one arbitrarily causing a panic if Report is called post close. This PR keeps r.queue open so that even if somehow the queue is filled after close() is called, it will never be flushed. An atomic flag might've worked here but didn't want to add extra sync given the channels already do that for us. 