### PR TITLE
Avoid rewriting copyright year in the license header

### DIFF
--- a/scripts/updateLicense.py
+++ b/scripts/updateLicense.py
@@ -50,10 +50,12 @@ def update_go_license(name, force=False):
         if year == CURRENT_YEAR:
             break
 
-        new_line = COPYRIGHT_RE.sub('Copyright (c) %d' % CURRENT_YEAR, line)
-        assert line != new_line, ('Could not change year in: %s' % line)
-        lines[i] = new_line
-        changed = True
+        # Avoid updating the copyright year.
+        #
+        # new_line = COPYRIGHT_RE.sub('Copyright (c) %d' % CURRENT_YEAR, line)
+        # assert line != new_line, ('Could not change year in: %s' % line)
+        # lines[i] = new_line
+        # changed = True
         break
 
     if not found:


### PR DESCRIPTION
Signed-off-by: Won Jun Jang <wjang@uber.com>

See https://github.com/jaegertracing/jaeger/commit/d7d1c74fa74f77d2c7faa50a0c568f979d9a30fd

I think we have too many repos... would it make sense to have this script in one place and have all the repos reference it?