### PR TITLE
Fix the RemotelyControlledSampler so that it terminates go-routine on Close()

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -495,6 +495,18 @@ func (s *RemotelyControlledSampler) pollControllerWithTicker(ticker *time.Ticker
 	}
 }
 
+func (s *RemotelyControlledSampler) getSampler() Sampler {
+	s.Lock()
+	defer s.Unlock()
+	return s.sampler
+}
+
+func (s *RemotelyControlledSampler) setSampler(sampler Sampler) {
+	s.Lock()
+	defer s.Unlock()
+	s.sampler = sampler
+}
+
 func (s *RemotelyControlledSampler) updateSampler() {
 	res, err := s.manager.GetSamplingStrategy(s.serviceName)
 	if err != nil {

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -310,7 +310,7 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	agent, remoteSampler, metricsFactory := initAgent(t)
 	defer agent.Close()
 
-	initSampler, ok := remoteSampler.sampler.(*ProbabilisticSampler)
+	initSampler, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
 
 	agent.AddSamplingStrategy("client app",
@@ -320,9 +320,9 @@ func TestRemotelyControlledSampler(t *testing.T) {
 		{Name: "jaeger.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
 		{Name: "jaeger.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
 	}...)
-	_, ok = remoteSampler.sampler.(*ProbabilisticSampler)
+	s1, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
-	assert.NotEqual(t, initSampler, remoteSampler.sampler, "Sampler should have been updated")
+	assert.NotEqual(t, initSampler, s1, "Sampler should have been updated")
 
 	sampled, tags := remoteSampler.IsSampled(TraceID{Low: testMaxID + 10}, testOperationName)
 	assert.False(t, sampled)
@@ -331,7 +331,7 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	assert.True(t, sampled)
 	assert.Equal(t, testProbabilisticExpectedTags, tags)
 
-	remoteSampler.sampler = initSampler
+	remoteSampler.setSampler(initSampler)
 
 	c := make(chan time.Time)
 	ticker := &time.Ticker{C: c}
@@ -341,9 +341,9 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	remoteSampler.Close()
 
-	_, ok = remoteSampler.sampler.(*ProbabilisticSampler)
+	s2, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
-	assert.NotEqual(t, initSampler, remoteSampler.sampler, "Sampler should have been updated from timer")
+	assert.NotEqual(t, initSampler, s2, "Sampler should have been updated from timer")
 
 	assert.True(t, remoteSampler.Equal(remoteSampler))
 }

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -332,11 +332,10 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	assert.Equal(t, testProbabilisticExpectedTags, tags)
 
 	remoteSampler.sampler = initSampler
+
 	c := make(chan time.Time)
-	remoteSampler.Lock()
-	remoteSampler.timer = &time.Ticker{C: c}
-	remoteSampler.Unlock()
-	go remoteSampler.pollController()
+	ticker := &time.Ticker{C: c}
+	go remoteSampler.pollControllerWithTicker(ticker)
 
 	c <- time.Now() // force update based on timer
 	time.Sleep(10 * time.Millisecond)
@@ -499,7 +498,7 @@ func (c *fakeSamplingManager) GetSamplingStrategy(serviceName string) (*sampling
 func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T) {
 	agent, remoteSampler, metricsFactory := initAgent(t)
 	defer agent.Close()
-	remoteSampler.Close() // stop timer-based updates, we want to call them manually
+	remoteSampler.Close() // close the second time (initAgent already called Close)
 
 	strategies := &sampling.PerOperationSamplingStrategies{
 		DefaultSamplingProbability:       testDefaultSamplingProbability,


### PR DESCRIPTION
Fixes #259 

Signed-off-by: Scott Kidder <scott@mux.com>