### PR TITLE
Move testify dependency to testImport

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -21,12 +21,6 @@ import:
   - tnet
   - trace/thrift/gen-go/tcollector
   - typed
-- package: github.com/stretchr/testify
-  version: ^1.1.3
-  subpackages:
-  - assert
-  - require
-  - suite
 - package: github.com/crossdock/crossdock-go
 - package: github.com/uber/jaeger-lib
   version: ^1.2.1
@@ -35,5 +29,11 @@ import:
 - package: github.com/pkg/errors
   version: ~0.8.0
 testImport:
+- package: github.com/stretchr/testify
+  version: ^1.1.3
+  subpackages:
+  - assert
+  - require
+  - suite
 - package: github.com/prometheus/client_golang
   version: v0.8.0


### PR DESCRIPTION
I've been having a lot of trouble with glide on a new service I'm developing. One error message involved conflicting dependencies of testify, and I think jaeger-client-go may be the cause. Either way, this seems like a good change.

Signed-off-by: Keith Lea <keithl@uber.com>