### PR TITLE
Use lock when retrieving span.Context()

### DIFF
--- a/span.go
+++ b/span.go
@@ -202,6 +202,8 @@ func (s *Span) FinishWithOptions(options opentracing.FinishOptions) {
 
 // Context implements opentracing.Span API
 func (s *Span) Context() opentracing.SpanContext {
+	s.Lock()
+	defer s.Unlock()
 	return s.context
 }
 


### PR DESCRIPTION
Resolves #267

Signed-off-by: Yuri Shkuro <ys@uber.com>