### PR TITLE
Modifies baggage parsing to remove leading/trailing whitespace from each pair

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -277,9 +277,9 @@ func (p *textMapPropagator) parseCommaSeparatedMap(value string) map[string]stri
 		return baggage
 	}
 	for _, kvpair := range strings.Split(value, ",") {
-		kv := strings.Split(strings.TrimSpace(kvpair), "=")
+		kv := strings.Split(kvpair, "=")
 		if len(kv) == 2 {
-			baggage[kv[0]] = kv[1]
+			baggage[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
 		} else {
 			log.Printf("Malformed value passed in for %s", p.headerKeys.JaegerBaggageHeader)
 		}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -212,7 +212,8 @@ func TestParseCommaSeparatedMap(t *testing.T) {
 		out map[string]string
 	}{
 		{"hobbit=Bilbo Baggins", map[string]string{"hobbit": "Bilbo Baggins"}},
-		{"hobbit=Bilbo Baggins, dwarf= Thrain", map[string]string{"hobbit": "Bilbo Baggins", "dwarf": " Thrain"}},
+		{"hobbit=Bilbo Baggins, dwarf= Thrain", map[string]string{"hobbit": "Bilbo Baggins", "dwarf": "Thrain"}},
+		{"hobbit = Bilbo Baggins , dwarf = Thrain ", map[string]string{"hobbit": "Bilbo Baggins", "dwarf": "Thrain"}},
 		{"kevin spacey=actor", map[string]string{"kevin spacey": "actor"}},
 		{"kevin%20spacey=se7en%3Aactor", map[string]string{"kevin spacey": "se7en:actor"}},
 		{"key1=, key2=", map[string]string{"key1": "", "key2": ""}},

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -206,7 +206,7 @@ func TestJaegerBaggageHeader(t *testing.T) {
 	)
 }
 
-func TestParseCommaSeperatedMap(t *testing.T) {
+func TestParseCommaSeparatedMap(t *testing.T) {
 	var testcases = []struct {
 		in  string
 		out map[string]string


### PR DESCRIPTION
Addresses issue #271 by splitting each key/value baggage pair, and _then_ trimming leading and trailing whitespace.

### Details
The comments in [the propagation code](https://github.com/jaegertracing/jaeger-client-go/blob/master/propagation.go#L267-L272) suggest that if I enter "key3 = value3 ", then the parsing code should return a map with the strings "key3", "value3" (note the lack of leading/trailing whitespace).

However, there is [an existing test case](https://github.com/jaegertracing/jaeger-client-go/blob/master/propagation_test.go#L215) that looks like it's expecting that the whitespace is preserved:

```
{"hobbit=Bilbo Baggins, dwarf= Thrain", map[string]string{"hobbit": "Bilbo Baggins", "dwarf": " Thrain"}},
```

I think it's counter-intuitive (not to mention inconsistent with the associated godoc comments) to preserve whitespace in this way, but maybe this was done intentionally for some reason?  If not, and this is indeed a bug, this PR will address it by stripping all leading/trailing whitespace _after_ splitting the key/value pairs.
