### PR TITLE
Add support for 128bit TraceIDs into zipkin Thrift

### DIFF
--- a/thrift-gen/zipkincore/ttypes.go
+++ b/thrift-gen/zipkincore/ttypes.go
@@ -983,7 +983,7 @@ func (p *Span) readField11(iprot thrift.TProtocol) error {
 
 func (p *Span) readField12(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadI64(); err != nil {
-		return thrift.PrependError("error reading field 1: ", err)
+		return thrift.PrependError("error reading field 12: ", err)
 	} else {
 		p.TraceIDHigh = &v
 	}
@@ -1178,8 +1178,8 @@ func (p *Span) writeField12(oprot thrift.TProtocol) (err error) {
 	if err := oprot.WriteFieldBegin("trace_id_high", thrift.I64, 12); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:trace_id: ", p), err)
 	}
-	if err := oprot.WriteI64(int64(p.TraceID)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.trace_id_high (1) field write error: ", p), err)
+	if err := oprot.WriteI64(int64(p.TraceIDHigh)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.trace_id_high (12) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field end error 12:trace_id_high: ", p), err)

--- a/thrift-gen/zipkincore/ttypes.go
+++ b/thrift-gen/zipkincore/ttypes.go
@@ -681,6 +681,7 @@ func (p *BinaryAnnotation) String() string {
 //  - BinaryAnnotations
 //  - Debug
 //  - Timestamp: Microseconds from epoch of the creation of this span.
+//  - TraceIDHigh : if set using 128 bit TraceID
 //
 // This value should be set directly by instrumentation, using the most
 // precise value possible. For example, gettimeofday or syncing nanoTime
@@ -719,6 +720,7 @@ type Span struct {
 	Debug             bool                `thrift:"debug,9" json:"debug,omitempty"`
 	Timestamp         *int64              `thrift:"timestamp,10" json:"timestamp,omitempty"`
 	Duration          *int64              `thrift:"duration,11" json:"duration,omitempty"`
+	TraceIDHigh 	  *int64 			  `thrift:"trace_id_high,12" json:"trace_id_high,omitempty"`
 }
 
 func NewSpan() *Span {
@@ -777,6 +779,16 @@ func (p *Span) GetDuration() int64 {
 	}
 	return *p.Duration
 }
+
+var Span_TraceIDHigh_DEFAULT int64
+
+func (p *Span) GetTraceIDHigh() int64 {
+	if !p.IsSetTraceIDHigh() {
+		return Span_TraceIDHigh_DEFAULT
+	}
+	return *p.TraceIDHigh
+}
+
 func (p *Span) IsSetParentID() bool {
 	return p.ParentID != nil
 }
@@ -791,6 +803,10 @@ func (p *Span) IsSetTimestamp() bool {
 
 func (p *Span) IsSetDuration() bool {
 	return p.Duration != nil
+}
+
+func (p *Span) IsSetTraceIDHigh() bool {
+	return p.TraceIDHigh != nil
 }
 
 func (p *Span) Read(iprot thrift.TProtocol) error {
@@ -841,6 +857,10 @@ func (p *Span) Read(iprot thrift.TProtocol) error {
 			}
 		case 11:
 			if err := p.readField11(iprot); err != nil {
+				return err
+			}
+		case 12:
+			if err := p.readField12(iprot); err != nil {
 				return err
 			}
 		default:
@@ -961,6 +981,15 @@ func (p *Span) readField11(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *Span) readField12(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI64(); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		p.TraceIDHigh = &v
+	}
+	return nil
+}
+
 func (p *Span) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("Span"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -990,6 +1019,9 @@ func (p *Span) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField11(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField12(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -1141,6 +1173,21 @@ func (p *Span) writeField11(oprot thrift.TProtocol) (err error) {
 	}
 	return err
 }
+
+func (p *Span) writeField12(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("trace_id_high", thrift.I64, 12); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:trace_id: ", p), err)
+	}
+	if err := oprot.WriteI64(int64(p.TraceID)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.trace_id_high (1) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 12:trace_id_high: ", p), err)
+	}
+	return err
+}
+
+
 
 func (p *Span) String() string {
 	if p == nil {

--- a/thrift-gen/zipkincore/ttypes.go
+++ b/thrift-gen/zipkincore/ttypes.go
@@ -1178,7 +1178,7 @@ func (p *Span) writeField12(oprot thrift.TProtocol) (err error) {
 	if err := oprot.WriteFieldBegin("trace_id_high", thrift.I64, 12); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:trace_id: ", p), err)
 	}
-	if err := oprot.WriteI64(int64(p.TraceIDHigh)); err != nil {
+	if err := oprot.WriteI64(int64(*p.TraceIDHigh)); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T.trace_id_high (12) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {

--- a/zipkin_thrift_span.go
+++ b/zipkin_thrift_span.go
@@ -46,6 +46,11 @@ var specialTagHandlers = map[string]func(*zipkinSpan, interface{}){
 func BuildZipkinThrift(s *Span) *z.Span {
 	span := &zipkinSpan{Span: s}
 	span.handleSpecialTags()
+	traceIDHigh := int64(span.context.traceID.High)
+	var ptrTraceIDHigh *int64
+	if traceIDHigh != 0 {
+		ptrTraceIDHigh = &traceIDHigh
+	}
 	parentID := int64(span.context.parentID)
 	var ptrParentID *int64
 	if parentID != 0 {
@@ -57,7 +62,8 @@ func BuildZipkinThrift(s *Span) *z.Span {
 		ServiceName: span.tracer.serviceName,
 		Ipv4:        int32(span.tracer.hostIPv4)}
 	thriftSpan := &z.Span{
-		TraceID:           int64(span.context.traceID.Low), // TODO upgrade zipkin thrift and use TraceIdHigh
+		TraceID:           int64(span.context.traceID.Low),
+		TraceIDHigh:       ptrTraceIDHigh,
 		ID:                int64(span.context.spanID),
 		ParentID:          ptrParentID,
 		Name:              span.operationName,


### PR DESCRIPTION
This pull request adds the missing TraceIDHigh into the zipkin thrift mapping.
I used the opentracing-zipkin thrift mappings and moved over the necessary additions.

Thanks.

