### PR TITLE
Use value receiver for config.NewTracer()

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ It is recommended to structure your `main()` so that it calls the `Close()` func
 before exiting, e.g.
 
 ```go
-tracer, closer, err := cfg.New(...)
+tracer, closer, err := cfg.NewTracer(...)
 defer closer.Close()
 ```
 
@@ -101,8 +101,9 @@ import (
 )
 
     metricsFactory := prometheus.New()
-    tracer, closer, err := new(config.Configuration).New(
-        "your-service-name",
+    tracer, closer, err := config.Configuration{
+        ServiceName: "your-service-name",
+    }.NewTracer(
         config.Metrics(metricsFactory),
     )
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -131,6 +131,7 @@ func (*nullCloser) Close() error { return nil }
 
 // New creates a new Jaeger Tracer, and a closer func that can be used to flush buffers
 // before shutdown.
+//
 // Deprecated: use NewTracer() function
 func (c Configuration) New(
 	serviceName string,
@@ -145,7 +146,7 @@ func (c Configuration) New(
 
 // NewTracer returns a new tracer based on the current configuration, using the given options,
 // and a closer func that can be used to flush buffers before shutdown.
-func (c *Configuration) NewTracer(options ...Option) (opentracing.Tracer, io.Closer, error) {
+func (c Configuration) NewTracer(options ...Option) (opentracing.Tracer, io.Closer, error) {
 	if c.ServiceName == "" {
 		return nil, nil, errors.New("no service name provided")
 	}

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -85,11 +85,11 @@ func ExampleConfiguration_InitGlobalTracer_production() {
 	// continue main()
 }
 
-func ExampleConfiguration_EnvironmentVariables() {
+func ExampleFromEnv() {
 	cfg, err := jaegercfg.FromEnv()
 	if err != nil {
 		// parsing errors might happen here, such as when we get a string where we expect a number
-		log.Printf("Could not initialize jaeger tracer: %s", err.Error())
+		log.Printf("Could not parse Jaeger env vars: %s", err.Error())
 		return
 	}
 
@@ -104,13 +104,13 @@ func ExampleConfiguration_EnvironmentVariables() {
 	// continue main()
 }
 
-func ExampleConfiguration_Override_EnvironmentVariables() {
+func ExampleFromEnv_override() {
 	os.Setenv("JAEGER_SERVICE_NAME", "not-effective")
 
 	cfg, err := jaegercfg.FromEnv()
 	if err != nil {
 		// parsing errors might happen here, such as when we get a string where we expect a number
-		log.Printf("Could not initialize jaeger tracer: %s", err.Error())
+		log.Printf("Could not parse Jaeger env vars: %s", err.Error())
 		return
 	}
 


### PR DESCRIPTION
The new function is defined on a pointer received, making it harder to use, e.g. below doesn't work even when using the `&`:

```go
	tracer, closer, err := &jaeger.Configuration{
		ServiceName: *name,
		Sampler:     &jaeger.SamplerConfig{Type: "const", Param: 1},
	}.NewTracer()
```

Also correct the naming of examples functions to match godoc guidelines, and fix README examples.