### PR TITLE
Fix throttler test by avoiding time.Sleep

### DIFF
--- a/internal/throttler/remote/throttler_test.go
+++ b/internal/throttler/remote/throttler_test.go
@@ -207,7 +207,7 @@ func TestRemotelyControlledThrottler_pollManager(t *testing.T) {
 			assert.True(t, throttler.IsAllowed(testOperation))
 			assert.False(t, throttler.IsAllowed(testOperation))
 
-			time.Sleep(throttler.refreshInterval * 2)
+			throttler.refreshCredits()
 			counters, _ := factory.Snapshot()
 			counter, ok := counters["jaeger.throttler_updates|result=ok"]
 			assert.True(t, ok)


### PR DESCRIPTION
Signed-off-by: Isaac Hier <ihier@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
#299 

## Short description of the changes
- Avoid use of `time.Sleep` and call function directly.
