### PR TITLE
Get rid of satori/go.uuid library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -97,12 +97,6 @@
   revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
-
-[[projects]]
   name = "github.com/stretchr/testify"
   packages = [
     "assert",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -159,6 +159,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a50aa1a3efea453448eb36bab5aeb2c0586fb8fc7ef9174be5317132c017a8bd"
+  inputs-digest = "f9dcfaf37a785c5dac1e20c29605eda29a83ba9c6f8842e92960dc94c8c4ff80"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/glide.lock
+++ b/glide.lock
@@ -55,8 +55,6 @@ imports:
   - internal/util
   - nfs
   - xfs
-- name: github.com/satori/go.uuid
-  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/stretchr/testify
   version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fd6c41bc00eee78db3b26109be1e5ac48f379ce327ff2c79da610f48d9270102
-updated: 2018-04-27T23:32:10.836621-04:00
+hash: 3accf84f97bff4a91162736104c0e9b9790820712bd86db6fec5e665f7196a82
+updated: 2018-04-30T11:46:43.804556-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -72,7 +72,7 @@ imports:
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: f85c78b1dd998214c5f2138155b320a4a43fbe36
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,8 +12,6 @@ import:
   - metrics
 - package: github.com/pkg/errors
   version: ~0.8.0
-- package: github.com/satori/go.uuid
-  version: ^1.2.0
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/tracer.go
+++ b/tracer.go
@@ -19,12 +19,12 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/satori/go.uuid"
 
 	"github.com/uber/jaeger-client-go/internal/baggage"
 	"github.com/uber/jaeger-client-go/internal/throttler"
@@ -154,7 +154,7 @@ func NewTracer(
 	}
 	t.process = Process{
 		Service: serviceName,
-		UUID:    uuid.NewV4().String(),
+		UUID:    strconv.FormatUint(t.randomNumber(), 16),
 		Tags:    t.tags,
 	}
 	if throttler, ok := t.debugThrottler.(ProcessSetter); ok {


### PR DESCRIPTION
Signed-off-by: Isaac Hier <ihier@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #292.

## Short description of the changes
- Remove UUID library in favor of 64 bit random numbers. Only needed to distinguish multiple clients acting on behalf of the same service communicating with a single agent. Even in the unlikely case of collision, the only outcome would be that debug spans might be disabled for clients longer than they should be, but nothing major.
