### PR TITLE
Add an example for Zipkin B3 Propagator

### DIFF
--- a/zipkin/README.md
+++ b/zipkin/README.md
@@ -9,6 +9,8 @@ for use with other Zipkin collectors.
 
 // ...
 import (
+  opentracing "github.com/opentracing/opentracing-go"
+  jaeger "github.com/uber/jaeger-client-go"
   "github.com/uber/jaeger-client-go/zipkin"
 )
 
@@ -17,7 +19,7 @@ func main() {
 	zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
 	injector := jaeger.TracerOptions.Injector(opentracing.HTTPHeaders, zipkinPropagator)
 	extractor := jaeger.TracerOptions.Extractor(opentracing.HTTPHeaders, zipkinPropagator)
-	
+
 	// Zipkin shares span ID between client and server spans; it must be enabled via the following option.
 	zipkinSharedRPCSpan := jaeger.TracerOptions.ZipkinSharedRPCSpan(true)
 
@@ -31,4 +33,41 @@ func main() {
 		zipkinSharedRPCSpan,
 	)
 }
+```
+
+If you'd like to follow the official guides from https://godoc.org/github.com/uber/jaeger-client-go/config#example-Configuration-InitGlobalTracer-Testing, here is an example.
+
+```go
+import (
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+	jaegerClientConfig "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/zipkin"
+)
+
+// Create jaeger config
+cfg := jaegerClientConfig.Configuration{
+  Sampler: &jaegerClientConfig.SamplerConfig{
+	Type:  "const",
+	Param: 1,
+  },
+  Reporter: &jaegerClientConfig.ReporterConfig{
+	LogSpans:            true,
+	BufferFlushInterval: 1 * time.Second,
+  },
+}
+
+// Zipkin shares span ID between client and server spans; it must be enabled via the following option.
+zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
+
+//Initialize tracer
+closer, err := cfg.InitGlobalTracer(
+  serviceName,
+  jaegerClientConfig.Logger(jaeger.StdLogger),
+  jaegerClientConfig.Injector(opentracing.HTTPHeaders, zipkinPropagator),
+  jaegerClientConfig.Extractor(opentracing.HTTPHeaders, zipkinPropagator),
+  jaegerClientConfig.ZipkinSharedRPCSpan(true),
+)
 ```

--- a/zipkin/README.md
+++ b/zipkin/README.md
@@ -50,42 +50,42 @@ import (
 	"github.com/uber/jaeger-client-go"
 	jaegerClientConfig "github.com/uber/jaeger-client-go/config"
 	"github.com/uber/jaeger-client-go/zipkin"
-    jaegerlog "github.com/uber/jaeger-client-go/log"
-    "github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-client-go/log"
+	"github.com/uber/jaeger-lib/metrics"
 )
 
 func main(){
-    //...
-
-    // Recommended configuration for production.
-    cfg := jaegercfg.Configuration{}
-
-   // Example logger and metrics factory. Use github.com/uber/jaeger-client-go/log
-   // and github.com/uber/jaeger-lib/metrics respectively to bind to real logging and metrics
-   // frameworks.
-   jLogger := jaegerlog.StdLogger
-   jMetricsFactory := metrics.NullFactory
-    
-   // Zipkin shares span ID between client and server spans; it must be enabled via the following option.
-   zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
-    
-   // Create tracer and then initialize global tracer
-   closer, err := cfg.InitGlobalTracer(
-     serviceName,
-     jaegercfg.Logger(jLogger),
-     jaegercfg.Metrics(jMetricsFactory),
-     jaegercfg.Injector(opentracing.HTTPHeaders, zipkinPropagator),
-     jaegercfg.Extractor(opentracing.HTTPHeaders, zipkinPropagator),
-     jaegercfg.ZipkinSharedRPCSpan(true),
-   )
-
-   if err != nil {
-       log.Printf("Could not initialize jaeger tracer: %s", err.Error())
-       return
-   }
-   defer closer.Close()
-
-   // continue main()
+	//...
+	
+	// Recommended configuration for production.
+	cfg := jaegercfg.Configuration{}
+	
+	// Example logger and metrics factory. Use github.com/uber/jaeger-client-go/log
+	// and github.com/uber/jaeger-lib/metrics respectively to bind to real logging and metrics
+	// frameworks.
+	jLogger := jaegerlog.StdLogger
+	jMetricsFactory := metrics.NullFactory
+	 
+	// Zipkin shares span ID between client and server spans; it must be enabled via the following option.
+	zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
+	 
+	// Create tracer and then initialize global tracer
+	closer, err := cfg.InitGlobalTracer(
+	  serviceName,
+	  jaegercfg.Logger(jLogger),
+	  jaegercfg.Metrics(jMetricsFactory),
+	  jaegercfg.Injector(opentracing.HTTPHeaders, zipkinPropagator),
+	  jaegercfg.Extractor(opentracing.HTTPHeaders, zipkinPropagator),
+	  jaegercfg.ZipkinSharedRPCSpan(true),
+	)
+	
+	if err != nil {
+	    log.Printf("Could not initialize jaeger tracer: %s", err.Error())
+	    return
+	}
+	defer closer.Close()
+	
+	// continue main()
 }
 
 ```

--- a/zipkin/README.md
+++ b/zipkin/README.md
@@ -9,9 +9,9 @@ for use with other Zipkin collectors.
 
 // ...
 import (
-  opentracing "github.com/opentracing/opentracing-go"
-  jaeger "github.com/uber/jaeger-client-go"
-  "github.com/uber/jaeger-client-go/zipkin"
+	opentracing "github.com/opentracing/opentracing-go"
+	jaeger "github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/zipkin"
 )
 
 func main() {


### PR DESCRIPTION
Signed-off-by: liukgg <liuk1991@sina.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Add an example to show how to use NewZipkinB3HTTPHeaderPropagator() while following the guides from official godoc(https://godoc.org/github.com/uber/jaeger-client-go/config#example-Configuration-InitGlobalTracer-Production). It's because I could not get straight guides when I tried to use jaeger with istio which uses the Zipkin B3 HTTP Header to propogate tracing data.

## Short description of the changes
Add a new example  to show how to use NewZipkinB3HTTPHeaderPropagator()  in the README.md file.
