### PR TITLE
WIP: Create composite propagator (#311)

### DIFF
--- a/header.go
+++ b/header.go
@@ -54,7 +54,9 @@ func (c *HeadersConfig) applyDefaults() *HeadersConfig {
 	return c
 }
 
-func getDefaultHeadersConfig() *HeadersConfig {
+// GetDefaultHeadersConfig returns an instance of HeadersConfig with the default values for the header keys used by
+// Jaeger.
+func GetDefaultHeadersConfig() *HeadersConfig {
 	return &HeadersConfig{
 		JaegerDebugHeader:        JaegerDebugHeader,
 		JaegerBaggageHeader:      JaegerBaggageHeader,

--- a/header_test.go
+++ b/header_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestSetDefaultOrCustom(t *testing.T) {
-	assert.Equal(t, (&HeadersConfig{}).applyDefaults(), getDefaultHeadersConfig())
+	assert.Equal(t, (&HeadersConfig{}).applyDefaults(), GetDefaultHeadersConfig())
 	assert.Equal(t, (&HeadersConfig{
 		JaegerDebugHeader: "custom-jaeger-debug-header",
 	}).applyDefaults(), &HeadersConfig{
@@ -41,7 +41,7 @@ func TestSetDefaultOrCustom(t *testing.T) {
 }
 
 func TestGetDefaultHeadersConfig(t *testing.T) {
-	assert.Equal(t, getDefaultHeadersConfig(), &HeadersConfig{
+	assert.Equal(t, GetDefaultHeadersConfig(), &HeadersConfig{
 		JaegerDebugHeader:        JaegerDebugHeader,
 		JaegerBaggageHeader:      JaegerBaggageHeader,
 		TraceContextHeaderName:   TraceContextHeaderName,

--- a/propagation.go
+++ b/propagation.go
@@ -64,7 +64,9 @@ type textMapPropagator struct {
 	decodeValue func(string) string
 }
 
-func NewTextMapPropagator(headerKeys *HeadersConfig, metrics Metrics) *textMapPropagator {
+// NewTextMapPropagator creates a Propagator for extracting and injecting Jaeger headers into SpanContexts  using the
+// TextMap format.
+func NewTextMapPropagator(headerKeys *HeadersConfig, metrics Metrics) Propagator {
 	return &textMapPropagator{
 		headerKeys: headerKeys,
 		metrics:    metrics,
@@ -77,7 +79,9 @@ func NewTextMapPropagator(headerKeys *HeadersConfig, metrics Metrics) *textMapPr
 	}
 }
 
-func NewHTTPHeaderPropagator(headerKeys *HeadersConfig, metrics Metrics) *textMapPropagator {
+// NewHTTPHeaderPropagator creates a Propagator for extracting and injecting Jaeger headers into SpanContexts  using the
+// HTTP format.
+func NewHTTPHeaderPropagator(headerKeys *HeadersConfig, metrics Metrics) Propagator {
 	return &textMapPropagator{
 		headerKeys: headerKeys,
 		metrics:    metrics,
@@ -99,7 +103,9 @@ type binaryPropagator struct {
 	buffers sync.Pool
 }
 
-func NewBinaryPropagator(tracer *Tracer) *binaryPropagator {
+// NewBinaryPropagator creates a Propagator for extracting and injecting Jaeger headers into SpanContexts  using the
+// Binary format.
+func NewBinaryPropagator(tracer *Tracer) Propagator {
 	return &binaryPropagator{
 		tracer:  tracer,
 		buffers: sync.Pool{New: func() interface{} { return &bytes.Buffer{} }},

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -222,7 +222,7 @@ func TestParseCommaSeperatedMap(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		m := (&textMapPropagator{
+		m := (&TextMapPropagator{
 			headerKeys: GetDefaultHeadersConfig(),
 		}).parseCommaSeparatedMap(testcase.in)
 		assert.Equal(t, testcase.out, m)

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -223,7 +223,7 @@ func TestParseCommaSeperatedMap(t *testing.T) {
 
 	for _, testcase := range testcases {
 		m := (&textMapPropagator{
-			headerKeys: getDefaultHeadersConfig(),
+			headerKeys: GetDefaultHeadersConfig(),
 		}).parseCommaSeparatedMap(testcase.in)
 		assert.Equal(t, testcase.out, m)
 	}

--- a/tracer.go
+++ b/tracer.go
@@ -95,13 +95,13 @@ func NewTracer(
 	}
 
 	// register default injectors/extractors unless they are already provided via options
-	textPropagator := newTextMapPropagator(getDefaultHeadersConfig(), t.metrics)
+	textPropagator := NewTextMapPropagator(GetDefaultHeadersConfig(), t.metrics)
 	t.addCodec(opentracing.TextMap, textPropagator, textPropagator)
 
-	httpHeaderPropagator := newHTTPHeaderPropagator(getDefaultHeadersConfig(), t.metrics)
+	httpHeaderPropagator := NewHTTPHeaderPropagator(GetDefaultHeadersConfig(), t.metrics)
 	t.addCodec(opentracing.HTTPHeaders, httpHeaderPropagator, httpHeaderPropagator)
 
-	binaryPropagator := newBinaryPropagator(t)
+	binaryPropagator := NewBinaryPropagator(t)
 	t.addCodec(opentracing.Binary, binaryPropagator, binaryPropagator)
 
 	// TODO remove after TChannel supports OpenTracing

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -51,10 +51,10 @@ func (tracerOptions) CustomHeaderKeys(headerKeys *HeadersConfig) TracerOption {
 		if headerKeys == nil {
 			return
 		}
-		textPropagator := newTextMapPropagator(headerKeys.applyDefaults(), tracer.metrics)
+		textPropagator := NewTextMapPropagator(headerKeys.applyDefaults(), tracer.metrics)
 		tracer.addCodec(opentracing.TextMap, textPropagator, textPropagator)
 
-		httpHeaderPropagator := newHTTPHeaderPropagator(headerKeys.applyDefaults(), tracer.metrics)
+		httpHeaderPropagator := NewHTTPHeaderPropagator(headerKeys.applyDefaults(), tracer.metrics)
 		tracer.addCodec(opentracing.HTTPHeaders, httpHeaderPropagator, httpHeaderPropagator)
 	}
 }

--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -23,16 +23,17 @@ import (
 	"github.com/uber/jaeger-client-go"
 )
 
-type zipkinB3HTTPHeaderPropagator struct{}
+// ZipkinB3HTTPHeaderPropagator can be used to extract and inject Zipkin HTTP B3 headers into SpanContexts.
+type ZipkinB3HTTPHeaderPropagator struct{}
 
 // NewZipkinB3HTTPHeaderPropagator creates a Propagator for extracting and injecting
 // Zipkin HTTP B3 headers into SpanContexts.
-func NewZipkinB3HTTPHeaderPropagator() jaeger.Propagator {
-	return &zipkinB3HTTPHeaderPropagator{}
+func NewZipkinB3HTTPHeaderPropagator() *ZipkinB3HTTPHeaderPropagator {
+	return &ZipkinB3HTTPHeaderPropagator{}
 }
 
 // Inject conforms to the Injector interface for decoding Zipkin HTTP B3 headers
-func (p *zipkinB3HTTPHeaderPropagator) Inject(
+func (p *ZipkinB3HTTPHeaderPropagator) Inject(
 	sc jaeger.SpanContext,
 	abstractCarrier interface{},
 ) error {
@@ -56,7 +57,7 @@ func (p *zipkinB3HTTPHeaderPropagator) Inject(
 }
 
 // Extract conforms to the Extractor interface for encoding Zipkin HTTP B3 headers
-func (p *zipkinB3HTTPHeaderPropagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
+func (p *ZipkinB3HTTPHeaderPropagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
 	textMapReader, ok := abstractCarrier.(opentracing.TextMapReader)
 	if !ok {
 		return jaeger.SpanContext{}, opentracing.ErrInvalidCarrier

--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -23,17 +23,16 @@ import (
 	"github.com/uber/jaeger-client-go"
 )
 
-// Propagator is an Injector and Extractor
-type Propagator struct{}
+type zipkinB3HTTPHeaderPropagator struct{}
 
 // NewZipkinB3HTTPHeaderPropagator creates a Propagator for extracting and injecting
 // Zipkin HTTP B3 headers into SpanContexts.
-func NewZipkinB3HTTPHeaderPropagator() Propagator {
-	return Propagator{}
+func NewZipkinB3HTTPHeaderPropagator() jaeger.Propagator {
+	return &zipkinB3HTTPHeaderPropagator{}
 }
 
 // Inject conforms to the Injector interface for decoding Zipkin HTTP B3 headers
-func (p Propagator) Inject(
+func (p *zipkinB3HTTPHeaderPropagator) Inject(
 	sc jaeger.SpanContext,
 	abstractCarrier interface{},
 ) error {
@@ -57,7 +56,7 @@ func (p Propagator) Inject(
 }
 
 // Extract conforms to the Extractor interface for encoding Zipkin HTTP B3 headers
-func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
+func (p *zipkinB3HTTPHeaderPropagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
 	textMapReader, ok := abstractCarrier.(opentracing.TextMapReader)
 	if !ok {
 		return jaeger.SpanContext{}, opentracing.ErrInvalidCarrier


### PR DESCRIPTION
Resolves #311

Exposed textMapPropagator and all its constructors.

Exposed getDefaultHeadersConfig to ease the creation of new
textMapPropagators.

Unified textMapPropagator and zipkinB3HTTPHeaderPropagator through a
common interface.

Create a new compositePropagator adhering to the new interface.

Signed-off-by: Hugo Fernandes <hugof225@gmail.com>
