### PR TITLE
Fix FollowsFrom spans ignoring baggage/debug header from dummy parent context

### DIFF
--- a/propagation_test.go
+++ b/propagation_test.go
@@ -179,31 +179,46 @@ func TestBaggagePropagationHTTP(t *testing.T) {
 }
 
 func TestJaegerBaggageHeader(t *testing.T) {
-	metricsFactory, metrics := initMetrics()
-	tracer, closer := NewTracer("DOOP",
-		NewConstSampler(true),
-		NewNullReporter(),
-		TracerOptions.Metrics(metrics),
-	)
-	defer closer.Close()
-
-	h := http.Header{}
-	h.Add(JaegerBaggageHeader, "key1=value1, key 2=value two")
-
-	ctx, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(h))
-	require.NoError(t, err)
-
-	sp := tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*Span)
-
-	assert.Equal(t, "value1", sp.BaggageItem("key1"))
-	assert.Equal(t, "value two", sp.BaggageItem("key 2"))
-
-	// ensure that traces.started counter is incremented, not traces.joined
-	testutils.AssertCounterMetrics(t, metricsFactory,
-		testutils.ExpectedMetric{
-			Name: "jaeger.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+	var testcases = []struct {
+		refFunc func(opentracing.SpanContext) opentracing.SpanReference
+	}{
+		{
+			refFunc: opentracing.ChildOf,
 		},
-	)
+		{
+			refFunc: opentracing.FollowsFrom,
+		},
+	}
+
+	for _, testcase := range testcases {
+
+		metricsFactory, metrics := initMetrics()
+		tracer, closer := NewTracer("DOOP",
+			NewConstSampler(true),
+			NewNullReporter(),
+			TracerOptions.Metrics(metrics),
+		)
+		defer closer.Close()
+
+		h := http.Header{}
+		h.Add(JaegerBaggageHeader, "key1=value1, key 2=value two")
+
+		ctx, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(h))
+		require.NoError(t, err)
+
+		sp := tracer.StartSpan("root", testcase.refFunc(ctx)).(*Span)
+
+		assert.Equal(t, "value1", sp.BaggageItem("key1"))
+		assert.Equal(t, "value two", sp.BaggageItem("key 2"))
+
+		// ensure that traces.started counter is incremented, not traces.joined
+		testutils.AssertCounterMetrics(t, metricsFactory,
+			testutils.ExpectedMetric{
+				Name: "jaeger.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+			},
+		)
+
+	}
 }
 
 func TestParseCommaSeperatedMap(t *testing.T) {
@@ -230,35 +245,51 @@ func TestParseCommaSeperatedMap(t *testing.T) {
 }
 
 func TestDebugCorrelationID(t *testing.T) {
-	metricsFactory, metrics := initMetrics()
-	tracer, closer := NewTracer("DOOP",
-		NewConstSampler(true),
-		NewNullReporter(),
-		TracerOptions.Metrics(metrics),
-	)
-	defer closer.Close()
-
-	h := http.Header{}
-	val := "value1"
-	h.Add(JaegerDebugHeader, val)
-	ctx, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(h))
-	require.NoError(t, err)
-	assert.EqualValues(t, 0, ctx.(SpanContext).parentID)
-	assert.EqualValues(t, val, ctx.(SpanContext).debugID)
-	sp := tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*Span)
-	assert.EqualValues(t, 0, sp.context.parentID)
-	assert.True(t, sp.context.traceID.IsValid())
-	assert.True(t, sp.context.IsSampled())
-	assert.True(t, sp.context.IsDebug())
-
-	tag := findDomainTag(sp, JaegerDebugHeader)
-	assert.NotNil(t, tag)
-	assert.Equal(t, val, tag.value)
-
-	// ensure that traces.started counter is incremented, not traces.joined
-	testutils.AssertCounterMetrics(t, metricsFactory,
-		testutils.ExpectedMetric{
-			Name: "jaeger.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+	var testcases = []struct {
+		refType string
+		refFunc func(opentracing.SpanContext) opentracing.SpanReference
+	}{
+		{
+			refFunc: opentracing.ChildOf,
 		},
-	)
+		{
+			refFunc: opentracing.FollowsFrom,
+		},
+	}
+
+	for _, testcase := range testcases {
+
+		metricsFactory, metrics := initMetrics()
+		tracer, closer := NewTracer("DOOP",
+			NewConstSampler(true),
+			NewNullReporter(),
+			TracerOptions.Metrics(metrics),
+		)
+		defer closer.Close()
+
+		h := http.Header{}
+		val := "value1"
+		h.Add(JaegerDebugHeader, val)
+		ctx, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(h))
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, ctx.(SpanContext).parentID)
+		assert.EqualValues(t, val, ctx.(SpanContext).debugID)
+		sp := tracer.StartSpan("root", testcase.refFunc(ctx)).(*Span)
+		assert.EqualValues(t, 0, sp.context.parentID)
+		assert.True(t, sp.context.traceID.IsValid())
+		assert.True(t, sp.context.IsSampled())
+		assert.True(t, sp.context.IsDebug())
+
+		tag := findDomainTag(sp, JaegerDebugHeader)
+		assert.NotNil(t, tag)
+		assert.Equal(t, val, tag.value)
+
+		// ensure that traces.started counter is incremented, not traces.joined
+		testutils.AssertCounterMetrics(t, metricsFactory,
+			testutils.ExpectedMetric{
+				Name: "jaeger.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+			},
+		)
+
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

This PR fixes the `StartSpan()` logic so that spans started with a `FollowsFrom` reference to a dummy parent (i.e., a parent used for carrying baggage items or debug ID extracted from HTTP headers) are set with the correct baggage items or debug ID, respectively.
Previously, these headers were in effect only if the span was started with a `ChildOf` reference to the dummy header.

## Short description of the changes

The condition used in `StartSpan()` to determine whether the `parent` variable holds a valid span context reference was extended to check if there's a debug ID / baggage items present.
The existing unit tests for baggage items / debug ID headers were also extended to repeat the test for both `ChildOf` and `FollowsFrom` reference types.


Signed-off-by: Zvi Cahana <zvic@il.ibm.com>