### PR TITLE
Make maximum annotation length configurable in tracer options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -218,6 +218,7 @@ func (c Configuration) NewTracer(options ...Option) (opentracing.Tracer, io.Clos
 		jaeger.TracerOptions.CustomHeaderKeys(c.Headers),
 		jaeger.TracerOptions.Gen128Bit(opts.gen128Bit),
 		jaeger.TracerOptions.ZipkinSharedRPCSpan(opts.zipkinSharedRPCSpan),
+		jaeger.TracerOptions.MaxTagValueLength(opts.maxTagValueLength),
 	}
 
 	for _, tag := range opts.tags {

--- a/config/options.go
+++ b/config/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	observers           []jaeger.Observer
 	gen128Bit           bool
 	zipkinSharedRPCSpan bool
+	maxTagValueLength   int
 	tags                []opentracing.Tag
 	injectors           map[interface{}]jaeger.Injector
 	extractors          map[interface{}]jaeger.Extractor
@@ -98,6 +99,13 @@ func Gen128Bit(gen128Bit bool) Option {
 func ZipkinSharedRPCSpan(zipkinSharedRPCSpan bool) Option {
 	return func(c *Options) {
 		c.zipkinSharedRPCSpan = zipkinSharedRPCSpan
+	}
+}
+
+// MaxTagValueLength can be provided to override the default max tag value length.
+func MaxTagValueLength(maxTagValueLength int) Option {
+	return func(c *Options) {
+		c.maxTagValueLength = maxTagValueLength
 	}
 }
 

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -38,6 +38,7 @@ func TestApplyOptions(t *testing.T) {
 		ContribObserver(contribObserver),
 		Gen128Bit(true),
 		ZipkinSharedRPCSpan(true),
+		MaxTagValueLength(1024),
 	)
 	assert.Equal(t, jaeger.StdLogger, opts.logger)
 	assert.Equal(t, sampler, opts.sampler)
@@ -46,6 +47,7 @@ func TestApplyOptions(t *testing.T) {
 	assert.Equal(t, []jaeger.ContribObserver{contribObserver}, opts.contribObservers)
 	assert.True(t, opts.gen128Bit)
 	assert.True(t, opts.zipkinSharedRPCSpan)
+	assert.Equal(t, 1024, opts.maxTagValueLength)
 }
 
 func TestTraceTagOption(t *testing.T) {

--- a/constants.go
+++ b/constants.go
@@ -82,4 +82,7 @@ const (
 
 	// DefaultUDPSpanServerPort is the default port to send the spans to, via UDP
 	DefaultUDPSpanServerPort = 6831
+
+	// DefaultMaxAnnotationLength is the default max length of byte array or string allowed in the annotations
+	DefaultMaxAnnotationLength = 256
 )

--- a/constants.go
+++ b/constants.go
@@ -83,6 +83,6 @@ const (
 	// DefaultUDPSpanServerPort is the default port to send the spans to, via UDP
 	DefaultUDPSpanServerPort = 6831
 
-	// DefaultMaxAnnotationLength is the default max length of byte array or string allowed in the annotations
-	DefaultMaxAnnotationLength = 256
+	// DefaultMaxTagValueLength is the default max length of byte array or string allowed in the tag value.
+	DefaultMaxTagValueLength = 256
 )

--- a/jaeger_thrift_span.go
+++ b/jaeger_thrift_span.go
@@ -38,7 +38,7 @@ func BuildJaegerThrift(span *Span) *j.Span {
 		Flags:         int32(span.context.flags),
 		StartTime:     startTime,
 		Duration:      duration,
-		Tags:          buildTags(span.tags, span.maxAnnotationLength),
+		Tags:          buildTags(span.tags, span.tracer.options.maxTagValueLength),
 		Logs:          buildLogs(span.logs),
 		References:    buildReferences(span.references),
 	}
@@ -55,7 +55,7 @@ func BuildJaegerProcessThrift(span *Span) *j.Process {
 func buildJaegerProcessThrift(tracer *Tracer) *j.Process {
 	process := &j.Process{
 		ServiceName: tracer.serviceName,
-		Tags:        buildTags(tracer.tags, tracer.options.maxAnnotationLength),
+		Tags:        buildTags(tracer.tags, tracer.options.maxTagValueLength),
 	}
 	if tracer.process.UUID != "" {
 		process.Tags = append(process.Tags, &j.Tag{Key: TracerUUIDTagKey, VStr: &tracer.process.UUID, VType: j.TagType_STRING})
@@ -63,10 +63,10 @@ func buildJaegerProcessThrift(tracer *Tracer) *j.Process {
 	return process
 }
 
-func buildTags(tags []Tag, maxAnnotationLength int64) []*j.Tag {
+func buildTags(tags []Tag, maxTagValueLength int) []*j.Tag {
 	jTags := make([]*j.Tag, 0, len(tags))
 	for _, tag := range tags {
-		jTag := buildTag(&tag, maxAnnotationLength)
+		jTag := buildTag(&tag, maxTagValueLength)
 		jTags = append(jTags, jTag)
 	}
 	return jTags
@@ -84,16 +84,16 @@ func buildLogs(logs []opentracing.LogRecord) []*j.Log {
 	return jLogs
 }
 
-func buildTag(tag *Tag, maxAnnotationLength int64) *j.Tag {
+func buildTag(tag *Tag, maxTagValueLength int) *j.Tag {
 	jTag := &j.Tag{Key: tag.key}
 	switch value := tag.value.(type) {
 	case string:
-		vStr := truncateString(value, maxAnnotationLength)
+		vStr := truncateString(value, maxTagValueLength)
 		jTag.VStr = &vStr
 		jTag.VType = j.TagType_STRING
 	case []byte:
-		if len(value) > int(maxAnnotationLength) {
-			value = value[:maxAnnotationLength]
+		if len(value) > maxTagValueLength {
+			value = value[:maxTagValueLength]
 		}
 		jTag.VBinary = value
 		jTag.VType = j.TagType_BINARY
@@ -150,7 +150,7 @@ func buildTag(tag *Tag, maxAnnotationLength int64) *j.Tag {
 		jTag.VBool = &vBool
 		jTag.VType = j.TagType_BOOL
 	default:
-		vStr := truncateString(stringify(value), maxAnnotationLength)
+		vStr := truncateString(stringify(value), maxTagValueLength)
 		jTag.VStr = &vStr
 		jTag.VType = j.TagType_STRING
 	}

--- a/jaeger_thrift_span.go
+++ b/jaeger_thrift_span.go
@@ -38,7 +38,7 @@ func BuildJaegerThrift(span *Span) *j.Span {
 		Flags:         int32(span.context.flags),
 		StartTime:     startTime,
 		Duration:      duration,
-		Tags:          buildTags(span.tags),
+		Tags:          buildTags(span.tags, span.maxAnnotationLength),
 		Logs:          buildLogs(span.logs),
 		References:    buildReferences(span.references),
 	}
@@ -55,7 +55,7 @@ func BuildJaegerProcessThrift(span *Span) *j.Process {
 func buildJaegerProcessThrift(tracer *Tracer) *j.Process {
 	process := &j.Process{
 		ServiceName: tracer.serviceName,
-		Tags:        buildTags(tracer.tags),
+		Tags:        buildTags(tracer.tags, tracer.options.maxAnnotationLength),
 	}
 	if tracer.process.UUID != "" {
 		process.Tags = append(process.Tags, &j.Tag{Key: TracerUUIDTagKey, VStr: &tracer.process.UUID, VType: j.TagType_STRING})
@@ -63,10 +63,10 @@ func buildJaegerProcessThrift(tracer *Tracer) *j.Process {
 	return process
 }
 
-func buildTags(tags []Tag) []*j.Tag {
+func buildTags(tags []Tag, maxAnnotationLength int64) []*j.Tag {
 	jTags := make([]*j.Tag, 0, len(tags))
 	for _, tag := range tags {
-		jTag := buildTag(&tag)
+		jTag := buildTag(&tag, maxAnnotationLength)
 		jTags = append(jTags, jTag)
 	}
 	return jTags
@@ -84,15 +84,15 @@ func buildLogs(logs []opentracing.LogRecord) []*j.Log {
 	return jLogs
 }
 
-func buildTag(tag *Tag) *j.Tag {
+func buildTag(tag *Tag, maxAnnotationLength int64) *j.Tag {
 	jTag := &j.Tag{Key: tag.key}
 	switch value := tag.value.(type) {
 	case string:
-		vStr := truncateString(value)
+		vStr := truncateString(value, maxAnnotationLength)
 		jTag.VStr = &vStr
 		jTag.VType = j.TagType_STRING
 	case []byte:
-		if len(value) > maxAnnotationLength {
+		if len(value) > int(maxAnnotationLength) {
 			value = value[:maxAnnotationLength]
 		}
 		jTag.VBinary = value
@@ -150,7 +150,7 @@ func buildTag(tag *Tag) *j.Tag {
 		jTag.VBool = &vBool
 		jTag.VType = j.TagType_BOOL
 	default:
-		vStr := truncateString(stringify(value))
+		vStr := truncateString(stringify(value), maxAnnotationLength)
 		jTag.VStr = &vStr
 		jTag.VType = j.TagType_STRING
 	}

--- a/jaeger_thrift_span_test.go
+++ b/jaeger_thrift_span_test.go
@@ -17,6 +17,7 @@ package jaeger
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -328,7 +329,7 @@ func TestJaegerSpanBaggageLogs(t *testing.T) {
 	assertJaegerTag(t, fields, "value", "token")
 }
 
-func TestJaegerMaxAnnotationLength(t *testing.T) {
+func TestJaegerMaxTagValueLength(t *testing.T) {
 	value := make([]byte, 512)
 	tests := []struct {
 		tagValueLength int
@@ -340,7 +341,7 @@ func TestJaegerMaxAnnotationLength(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		func() {
+		t.Run(strconv.Itoa(test.tagValueLength), func(t *testing.T) {
 			tracer, closer := NewTracer("DOOP",
 				NewConstSampler(true),
 				NewNullReporter(),
@@ -357,7 +358,7 @@ func TestJaegerMaxAnnotationLength(t *testing.T) {
 			bytesTag := findTag(thriftSpan, "tag.bytes")
 			assert.Equal(t, j.TagType_BINARY, bytesTag.VType)
 			assert.Equal(t, test.expected, bytesTag.VBinary)
-		}()
+		})
 	}
 }
 

--- a/jaeger_thrift_span_test.go
+++ b/jaeger_thrift_span_test.go
@@ -284,7 +284,7 @@ func TestBuildTags(t *testing.T) {
 	}
 	for i, test := range tests {
 		testName := fmt.Sprintf("test-%02d", i)
-		actual := buildTags([]Tag{test.tag}, DefaultMaxAnnotationLength)
+		actual := buildTags([]Tag{test.tag}, DefaultMaxTagValueLength)
 		assert.Len(t, actual, 1)
 		compareTags(t, test.expected, actual[0], testName)
 	}
@@ -331,9 +331,9 @@ func TestJaegerSpanBaggageLogs(t *testing.T) {
 func TestJaegerMaxAnnotationLength(t *testing.T) {
 	value := make([]byte, 512)
 	tests := []struct {
-		annotationLength int64
-		value            []byte
-		expected         []byte
+		tagValueLength int
+		value          []byte
+		expected       []byte
 	}{
 		{256, value, value[:256]},
 		{512, value, value},
@@ -344,7 +344,7 @@ func TestJaegerMaxAnnotationLength(t *testing.T) {
 			tracer, closer := NewTracer("DOOP",
 				NewConstSampler(true),
 				NewNullReporter(),
-				TracerOptions.MaxAnnotationLength(test.annotationLength))
+				TracerOptions.MaxTagValueLength(test.tagValueLength))
 			defer closer.Close()
 			sp := tracer.StartSpan("s1").(*Span)
 			sp.SetTag("tag.string", string(test.value))

--- a/span.go
+++ b/span.go
@@ -57,9 +57,6 @@ type Span struct {
 	references []Reference
 
 	observer ContribSpanObserver
-
-	// the max length of byte array or string allowed in the annotations
-	maxAnnotationLength int64
 }
 
 // Tag is a simple key value wrapper.

--- a/span.go
+++ b/span.go
@@ -57,6 +57,9 @@ type Span struct {
 	references []Reference
 
 	observer ContribSpanObserver
+
+	// the max length of byte array or string allowed in the annotations
+	maxAnnotationLength int64
 }
 
 // Tag is a simple key value wrapper.

--- a/tracer.go
+++ b/tracer.go
@@ -50,7 +50,7 @@ type Tracer struct {
 		gen128Bit            bool // whether to generate 128bit trace IDs
 		zipkinSharedRPCSpan  bool
 		highTraceIDGenerator func() uint64 // custom high trace ID generator
-		maxAnnotationLength  int64
+		maxTagValueLength    int
 		// more options to come
 	}
 	// pool for Span objects
@@ -153,8 +153,8 @@ func NewTracer(
 		t.logger.Error("Overriding high trace ID generator but not generating " +
 			"128 bit trace IDs, consider enabling the \"Gen128Bit\" option")
 	}
-	if t.options.maxAnnotationLength == 0 {
-		t.options.maxAnnotationLength = DefaultMaxAnnotationLength
+	if t.options.maxTagValueLength == 0 {
+		t.options.maxTagValueLength = DefaultMaxTagValueLength
 	}
 	t.process = Process{
 		Service: serviceName,
@@ -288,7 +288,6 @@ func (t *Tracer) startSpanWithOptions(
 		newTrace,
 		rpcServer,
 		references,
-		t.options.maxAnnotationLength,
 	)
 }
 
@@ -360,14 +359,12 @@ func (t *Tracer) startSpanInternal(
 	newTrace bool,
 	rpcServer bool,
 	references []Reference,
-	maxAnnotationLength int64,
 ) *Span {
 	sp.tracer = t
 	sp.operationName = operationName
 	sp.startTime = startTime
 	sp.duration = 0
 	sp.references = references
-	sp.maxAnnotationLength = maxAnnotationLength
 	sp.firstInProcess = rpcServer || sp.context.parentID == 0
 	if len(tags) > 0 || len(internalTags) > 0 {
 		sp.tags = make([]Tag, len(internalTags), len(tags)+len(internalTags))

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -128,9 +128,9 @@ func (tracerOptions) HighTraceIDGenerator(highTraceIDGenerator func() uint64) Tr
 	}
 }
 
-func (tracerOptions) MaxAnnotationLength(maxAnnotationLength int64) TracerOption {
+func (tracerOptions) MaxTagValueLength(maxTagValueLength int) TracerOption {
 	return func(tracer *Tracer) {
-		tracer.options.maxAnnotationLength = maxAnnotationLength
+		tracer.options.maxTagValueLength = maxTagValueLength
 	}
 }
 

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -128,6 +128,12 @@ func (tracerOptions) HighTraceIDGenerator(highTraceIDGenerator func() uint64) Tr
 	}
 }
 
+func (tracerOptions) MaxAnnotationLength(maxAnnotationLength int64) TracerOption {
+	return func(tracer *Tracer) {
+		tracer.options.maxAnnotationLength = maxAnnotationLength
+	}
+}
+
 func (tracerOptions) ZipkinSharedRPCSpan(zipkinSharedRPCSpan bool) TracerOption {
 	return func(tracer *Tracer) {
 		tracer.options.zipkinSharedRPCSpan = zipkinSharedRPCSpan

--- a/zipkin_thrift_span_test.go
+++ b/zipkin_thrift_span_test.go
@@ -17,6 +17,7 @@ package jaeger
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -310,7 +311,7 @@ func TestBaggageLogs(t *testing.T) {
 	assert.NotNil(t, findAnnotation(thriftSpan, `{"event":"baggage","key":"auth.token","value":"token"}`))
 }
 
-func TestMaxAnnotationLength(t *testing.T) {
+func TestMaxTagValueLength(t *testing.T) {
 	value := make([]byte, 512)
 	tests := []struct {
 		tagValueLength int
@@ -322,7 +323,7 @@ func TestMaxAnnotationLength(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		func() {
+		t.Run(strconv.Itoa(test.tagValueLength), func(t *testing.T) {
 			tracer, closer := NewTracer("DOOP",
 				NewConstSampler(true),
 				NewNullReporter(),
@@ -335,7 +336,7 @@ func TestMaxAnnotationLength(t *testing.T) {
 			thriftSpan := BuildZipkinThrift(sp)
 			assert.Equal(t, test.expected, findBinaryAnnotation(thriftSpan, "tag.string").Value)
 			assert.Equal(t, test.expected, findBinaryAnnotation(thriftSpan, "tag.bytes").Value)
-		}()
+		})
 	}
 }
 

--- a/zipkin_thrift_span_test.go
+++ b/zipkin_thrift_span_test.go
@@ -313,9 +313,9 @@ func TestBaggageLogs(t *testing.T) {
 func TestMaxAnnotationLength(t *testing.T) {
 	value := make([]byte, 512)
 	tests := []struct {
-		annotationLength int64
-		value            []byte
-		expected         []byte
+		tagValueLength int
+		value          []byte
+		expected       []byte
 	}{
 		{256, value, value[:256]},
 		{512, value, value},
@@ -326,7 +326,7 @@ func TestMaxAnnotationLength(t *testing.T) {
 			tracer, closer := NewTracer("DOOP",
 				NewConstSampler(true),
 				NewNullReporter(),
-				TracerOptions.MaxAnnotationLength(test.annotationLength))
+				TracerOptions.MaxTagValueLength(test.tagValueLength))
 			defer closer.Close()
 			sp := tracer.StartSpan("s1").(*Span)
 			sp.SetTag("tag.string", string(test.value))


### PR DESCRIPTION
Fix #314 #232

Related to #316 

Instead of removing the truncated string and max annotation length, make the max annotation length configurable in tracer options for backward compatibility. Maybe we can also support no limit for max annotation length. but that is open for discussion.

Signed-off-by: Eric Chang <chiahan1123@gmail.com>