### PR TITLE
Allow setting of PoolSpans from Config object

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -217,6 +217,7 @@ func (c Configuration) NewTracer(options ...Option) (opentracing.Tracer, io.Clos
 		jaeger.TracerOptions.Logger(opts.logger),
 		jaeger.TracerOptions.CustomHeaderKeys(c.Headers),
 		jaeger.TracerOptions.Gen128Bit(opts.gen128Bit),
+		jaeger.TracerOptions.PoolSpans(opts.poolSpans),
 		jaeger.TracerOptions.ZipkinSharedRPCSpan(opts.zipkinSharedRPCSpan),
 	}
 

--- a/config/options.go
+++ b/config/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	contribObservers    []jaeger.ContribObserver
 	observers           []jaeger.Observer
 	gen128Bit           bool
+	poolSpans           bool
 	zipkinSharedRPCSpan bool
 	tags                []opentracing.Tag
 	injectors           map[interface{}]jaeger.Injector
@@ -89,6 +90,13 @@ func ContribObserver(observer jaeger.ContribObserver) Option {
 func Gen128Bit(gen128Bit bool) Option {
 	return func(c *Options) {
 		c.gen128Bit = gen128Bit
+	}
+}
+
+// PoolSpans specifies whether to pool spans
+func PoolSpans(poolSpans bool) Option {
+	return func(c *Options) {
+		c.poolSpans = poolSpans
 	}
 }
 

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -37,6 +37,7 @@ func TestApplyOptions(t *testing.T) {
 		Sampler(sampler),
 		ContribObserver(contribObserver),
 		Gen128Bit(true),
+		PoolSpans(true),
 		ZipkinSharedRPCSpan(true),
 	)
 	assert.Equal(t, jaeger.StdLogger, opts.logger)
@@ -45,6 +46,7 @@ func TestApplyOptions(t *testing.T) {
 	assert.Equal(t, []jaeger.Observer{observer}, opts.observers)
 	assert.Equal(t, []jaeger.ContribObserver{contribObserver}, opts.contribObservers)
 	assert.True(t, opts.gen128Bit)
+	assert.True(t, opts.poolSpans)
 	assert.True(t, opts.zipkinSharedRPCSpan)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- lack of support for enabling pooling of spans from config object

## Short description of the changes
- add Config setter for PoolSpans and pipe it through to Tracer construction
