### PR TITLE
Rename JAEGER_SAMPLER_MANAGER_HOST_PORT to JAEGER_CONFIG_MANAGER_HOST_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ JAEGER_REPORTER_MAX_QUEUE_SIZE | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | The reporter's flush interval (ms)
 JAEGER_SAMPLER_TYPE | The sampler type
 JAEGER_SAMPLER_PARAM | The sampler parameter (number)
-JAEGER_SAMPLER_MANAGER_HOST_PORT | The host name and port when using the remote controlled sampler
+JAEGER_SAMPLER_MANAGER_HOST_PORT | The host name and port when using the remote controlled sampler (deprecated, use JAEGER_CONFIG_MANAGER_HOST_PORT)
+JAEGER_CONFIG_MANAGER_HOST_PORT | The host name and port when using remote sampling configuration
 JAEGER_SAMPLER_MAX_OPERATIONS | The maximum number of operations that the sampler will keep track of
 JAEGER_SAMPLER_REFRESH_INTERVAL | How often the remotely controlled sampler will poll jaeger-agent for the appropriate sampling strategy
 JAEGER_TAGS | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,7 @@ type SamplerConfig struct {
 	Param float64 `yaml:"param"`
 
 	// SamplingServerURL is the address of jaeger-agent's HTTP sampling server
-	// Can be set by exporting an environment variable named JAEGER_SAMPLER_MANAGER_HOST_PORT
+	// Can be set by exporting an environment variable named JAEGER_CONFIG_MANAGER_HOST_PORT
 	SamplingServerURL string `yaml:"samplingServerURL"`
 
 	// MaxOperations is the maximum number of operations that the sampler

--- a/config/config_env.go
+++ b/config/config_env.go
@@ -36,6 +36,7 @@ const (
 	envTags                   = "JAEGER_TAGS"
 	envSamplerType            = "JAEGER_SAMPLER_TYPE"
 	envSamplerParam           = "JAEGER_SAMPLER_PARAM"
+	envConfigManagerHostPort  = "JAEGER_CONFIG_MANAGER_HOST_PORT"
 	envSamplerManagerHostPort = "JAEGER_SAMPLER_MANAGER_HOST_PORT"
 	envSamplerMaxOperations   = "JAEGER_SAMPLER_MAX_OPERATIONS"
 	envSamplerRefreshInterval = "JAEGER_SAMPLER_REFRESH_INTERVAL"
@@ -108,8 +109,14 @@ func samplerConfigFromEnv() (*SamplerConfig, error) {
 		}
 	}
 
-	if e := os.Getenv(envSamplerManagerHostPort); e != "" {
+	if e := os.Getenv(envConfigManagerHostPort); e != "" {
 		sc.SamplingServerURL = e
+	} else {
+		// deprecated
+		if e = os.Getenv(envSamplerManagerHostPort); e != "" {
+			jaeger.StdLogger.Infof("deprecated: Please use JAEGER_CONFIG_MANAGER_HOST_PORT")
+			sc.SamplingServerURL = e
+		}
 	}
 
 	if e := os.Getenv(envSamplerMaxOperations); e != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,9 +116,11 @@ func TestNoServiceNameFromEnv(t *testing.T) {
 
 func TestSamplerConfigFromEnv(t *testing.T) {
 	// prepare
+	testMgrHostPort := "http://themaster:80"
 	os.Setenv(envSamplerType, "const")
 	os.Setenv(envSamplerParam, "1")
-	os.Setenv(envSamplerManagerHostPort, "http://themaster")
+	os.Setenv(envConfigManagerHostPort, testMgrHostPort)
+	os.Setenv(envSamplerManagerHostPort, testMgrHostPort) // deprecated
 	os.Setenv(envSamplerMaxOperations, "10")
 	os.Setenv(envSamplerRefreshInterval, "1m1s") // 61 seconds
 
@@ -129,7 +131,7 @@ func TestSamplerConfigFromEnv(t *testing.T) {
 	// verify
 	assert.Equal(t, "const", cfg.Sampler.Type)
 	assert.Equal(t, float64(1), cfg.Sampler.Param)
-	assert.Equal(t, "http://themaster", cfg.Sampler.SamplingServerURL)
+	assert.Equal(t, testMgrHostPort, cfg.Sampler.SamplingServerURL)
 	assert.Equal(t, int(10), cfg.Sampler.MaxOperations)
 	assert.Equal(t, 61000000000, int(cfg.Sampler.SamplingRefreshInterval))
 


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/jaeger-client-go/issues/282

## Short description of the changes
Renames the environment variable `JAEGER_SAMPLER_MANAGER_HOST_PORT` to `JAEGER_CONFIG_MANAGER_HOST_PORT` to denote the endpoint is not just for setting sampling server but rather is the endpoint for remote sampling configuration.

Signed-off-by: Masroor Hasan masroor.hasan.n@gmail.com