### PR TITLE
zipkin transport: return error when an HTTP error code is seen (#330)

### DIFF
--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -27,6 +27,8 @@ package zipkin
 
 import (
 	"bytes"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -160,7 +162,20 @@ func (c *HTTPTransport) send(spans []*zipkincore.Span) error {
 		req.SetBasicAuth(c.httpCredentials.username, c.httpCredentials.password)
 	}
 
-	_, err = c.client.Do(req)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
 
-	return err
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("could not read response from collector: %s", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("error from collector: code=%d body=%q", resp.StatusCode, string(respBytes))
+	}
+
+	return nil
 }

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -26,8 +26,10 @@ package zipkin
 // https://github.com/openzipkin/zipkin-go-opentracing/
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -41,11 +43,15 @@ import (
 	"github.com/uber/jaeger-client-go/thrift-gen/zipkincore"
 )
 
+const spanPath = "/api/v1/spans"
+
 func TestHttpTransport(t *testing.T) {
 	server := newHTTPServer(t)
+	defer server.Close()
+
 	httpUsername := "Aphex"
 	httpPassword := "Twin"
-	sender, err := NewHTTPTransport("http://localhost:10000/api/v1/spans", HTTPBasicAuth(httpUsername, httpPassword))
+	sender, err := NewHTTPTransport(server.SpanURL(), HTTPBasicAuth(httpUsername, httpPassword))
 	require.NoError(t, err)
 
 	tracer, closer := jaeger.NewTracer(
@@ -99,11 +105,78 @@ func TestHTTPOptions(t *testing.T) {
 	assert.Equal(t, "kuzhambu", sender.httpCredentials.password)
 }
 
+type recordingLogger struct {
+	errors []string
+}
+
+func (r *recordingLogger) Error(msg string) {
+	r.errors = append(r.errors, msg)
+}
+
+func (r *recordingLogger) Infof(msg string, args ...interface{}) {}
+
+func TestHTTPErrorLogging(t *testing.T) {
+	type testCase struct {
+		URL                   string
+		expectErrorSubstrings []string
+	}
+
+	s := newHTTPServer(t)
+	defer s.Close()
+
+	tcs := []testCase{
+		{ // good case
+			URL: s.SpanURL(),
+		},
+		{ // bad URL path
+			URL: s.httpServer.URL + "/bad_suffix",
+			expectErrorSubstrings: []string{"error from collector: code=404"},
+		},
+		{ // bad URL scheme
+			URL: "badscheme://localhost:10001",
+			expectErrorSubstrings: []string{"error when flushing the buffer"},
+		},
+	}
+
+	for _, tc := range tcs {
+		logger := new(recordingLogger)
+
+		sender, err := NewHTTPTransport(tc.URL)
+		require.NoError(t, err)
+		tracer, closer := jaeger.NewTracer(
+			"test",
+			jaeger.NewConstSampler(true),
+			jaeger.NewRemoteReporter(sender, jaeger.ReporterOptions.Logger(logger)),
+		)
+
+		span := tracer.StartSpan("root")
+		span.Finish()
+
+		closer.Close()
+
+		expectedNumErrors := len(tc.expectErrorSubstrings)
+		require.Len(t, logger.errors, expectedNumErrors, fmt.Sprintf("the number of errors is not equal to %d", expectedNumErrors))
+
+		for i, subStr := range tc.expectErrorSubstrings {
+			assert.Contains(t, logger.errors[i], subStr)
+		}
+	}
+}
+
 type httpServer struct {
 	t               *testing.T
 	zipkinSpans     []*zipkincore.Span
 	authCredentials []*HTTPBasicAuthCredentials
 	mutex           sync.RWMutex
+	httpServer      *httptest.Server
+}
+
+func (s *httpServer) SpanURL() string {
+	return s.httpServer.URL + spanPath
+}
+
+func (s *httpServer) Close() {
+	s.httpServer.Close()
 }
 
 func (s *httpServer) spans() []*zipkincore.Span {
@@ -125,7 +198,12 @@ func newHTTPServer(t *testing.T) *httpServer {
 		authCredentials: make([]*HTTPBasicAuthCredentials, 0),
 		mutex:           sync.RWMutex{},
 	}
-	http.HandleFunc("/api/v1/spans", func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != spanPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
 		contextType := r.Header.Get("Content-Type")
 		if contextType != "application/x-thrift" {
 			t.Errorf(
@@ -169,10 +247,7 @@ func newHTTPServer(t *testing.T) *httpServer {
 		u, p, _ := r.BasicAuth()
 		server.authCredentials = append(server.authCredentials, &HTTPBasicAuthCredentials{username: u, password: p})
 	})
-
-	go func() {
-		http.ListenAndServe(":10000", nil)
-	}()
+	server.httpServer = httptest.NewServer(handler)
 
 	return server
 }


### PR DESCRIPTION
Signed-off-by: Michael Puncel <mpuncel@squareup.com>

## Which problem is this PR solving?
- The zipkin HTTP transport silently swallows HTTP errors, for instance when the URL path is misconfigured and getting 404s when flushing spans

## Short description of the changes
- Return an error if the HTTP response code is >= 400 (which is what the normal jaeger transport does)
- Read entire response body and close it to ensure connections don't leak
