### PR TITLE
collector http transport: support custom http.RoundTripper (#332)

### DIFF
--- a/transport/http.go
+++ b/transport/http.go
@@ -68,6 +68,14 @@ func HTTPBasicAuth(username string, password string) HTTPOption {
 	}
 }
 
+// HTTPRoundTripper configures the underlying Transport on the *http.Client
+// that is used
+func HTTPRoundTripper(transport http.RoundTripper) HTTPOption {
+	return func(c *HTTPTransport) {
+		c.client.Transport = transport
+	}
+}
+
 // NewHTTPTransport returns a new HTTP-backend transport. url should be an http
 // url of the collector to handle POST request, typically something like:
 //     http://hostname:14268/api/traces?format=jaeger.thrift

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -80,13 +80,18 @@ func TestHTTPTransport(t *testing.T) {
 }
 
 func TestHTTPOptions(t *testing.T) {
+	roundTripper := &http.Transport{
+		MaxIdleConns: 80000,
+	}
 	sender := NewHTTPTransport(
 		"some url",
 		HTTPBatchSize(123),
 		HTTPTimeout(123*time.Millisecond),
+		HTTPRoundTripper(roundTripper),
 	)
 	assert.Equal(t, 123, sender.batchSize)
 	assert.Equal(t, 123*time.Millisecond, sender.client.Timeout)
+	assert.Equal(t, roundTripper, sender.client.Transport)
 }
 
 type httpServer struct {

--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -84,6 +84,14 @@ func HTTPBasicAuth(username string, password string) HTTPOption {
 	}
 }
 
+// HTTPRoundTripper configures the underlying Transport on the *http.Client
+// that is used
+func HTTPRoundTripper(transport http.RoundTripper) HTTPOption {
+	return func(c *HTTPTransport) {
+		c.client.Transport = transport
+	}
+}
+
 // NewHTTPTransport returns a new HTTP-backend transport. url should be an http
 // url to handle post request, typically something like:
 //     http://hostname:9411/api/v1/spans

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -84,12 +84,16 @@ func TestHttpTransport(t *testing.T) {
 }
 
 func TestHTTPOptions(t *testing.T) {
+	roundTripper := &http.Transport{
+		MaxIdleConns: 80000,
+	}
 	sender, err := NewHTTPTransport(
 		"some url",
 		HTTPLogger(log.StdLogger),
 		HTTPBatchSize(123),
 		HTTPTimeout(123*time.Millisecond),
 		HTTPBasicAuth("urundai", "kuzhambu"),
+		HTTPRoundTripper(roundTripper),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, log.StdLogger, sender.logger)
@@ -97,6 +101,7 @@ func TestHTTPOptions(t *testing.T) {
 	assert.Equal(t, 123*time.Millisecond, sender.client.Timeout)
 	assert.Equal(t, "urundai", sender.httpCredentials.username)
 	assert.Equal(t, "kuzhambu", sender.httpCredentials.password)
+	assert.Equal(t, roundTripper, sender.client.Transport)
 }
 
 type httpServer struct {


### PR DESCRIPTION
Adds an HTTPOption to the HTTP exporters that allows overriding the
underlying http.RoundTripper to use on the *http.Client. This is useful
for designs that require more flexibility than just a URL, for instance
when forwarding spans to a local Envoy proxy over a unix domain socket.

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- This PR allows overriding the `http.RoundTripper` on the HTTP exporters' underlying `*http.Client`s. This is useful for use cases like forwarding span data to a unix domain socket.

## Short description of the changes
- Adds an `HTTPOption` for setting `http.RoundTripper` on the various HTTP exporters
