### PR TITLE
Fix golint import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ install-ci: install-dep-ci install
 	go get github.com/wadey/gocovmerge
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cmd/cover
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 
 .PHONY: test-ci
 test-ci:


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fix build break
```
package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
make: *** [install-ci] Error 1
```
- https://github.com/golang/lint/issues/415#issuecomment-429050481
- https://travis-ci.org/eundoosong/jaeger-client-go/builds/445113715?utm_source=github_status&utm_medium=notification

