### PR TITLE
Make JAEGER_ENDPOINT more priority over JAEGER_AGENT_XXX

### DIFF
--- a/config/config_env.go
+++ b/config/config_env.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/uber/jaeger-client-go"
@@ -159,46 +159,37 @@ func reporterConfigFromEnv() (*ReporterConfig, error) {
 		}
 	}
 
-	host := jaeger.DefaultUDPSpanServerHost
-	ep := os.Getenv(envEndpoint)
-	if e := os.Getenv(envAgentHost); e != "" {
-		if ep != "" {
-			return nil, errors.Errorf("cannot set env vars %s and %s together", envAgentHost, envEndpoint)
-		}
-		host = e
-	}
-
-	port := jaeger.DefaultUDPSpanServerPort
-	if e := os.Getenv(envAgentPort); e != "" {
-		if ep != "" {
-			return nil, errors.Errorf("cannot set env vars %s and %s together", envAgentPort, envEndpoint)
-		}
-		if value, err := strconv.ParseInt(e, 10, 0); err == nil {
-			port = int(value)
-		} else {
-			return nil, errors.Wrapf(err, "cannot parse env var %s=%s", envAgentPort, e)
-		}
-	}
-
-	// the side effect of this is that we are building the default value, even if none of the env vars
-	// were not explicitly passed
-	rc.LocalAgentHostPort = fmt.Sprintf("%s:%d", host, port)
-
-	if ep != "" {
-		u, err := url.ParseRequestURI(ep)
+	if e := os.Getenv(envEndpoint); e != "" {
+		u, err := url.ParseRequestURI(e)
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot parse env var %s=%s", envEndpoint, ep)
+			return nil, errors.Wrapf(err, "cannot parse env var %s=%s", envEndpoint, e)
 		}
 		rc.CollectorEndpoint = fmt.Sprintf("%s", u)
-	}
+		user := os.Getenv(envUser)
+		pswd := os.Getenv(envPassword)
+		if user != "" && pswd == "" || user == "" && pswd != "" {
+			return nil, errors.Errorf("you must set %s and %s env vars together", envUser, envPassword)
+		}
+		rc.User = user
+		rc.Password = pswd
+	} else {
+		host := jaeger.DefaultUDPSpanServerHost
+		if e := os.Getenv(envAgentHost); e != "" {
+			host = e
+		}
 
-	user := os.Getenv(envUser)
-	pswd := os.Getenv(envPassword)
-	if user != "" && pswd == "" || user == "" && pswd != "" {
-		return nil, errors.Errorf("you must set %s and %s env vars together", envUser, envPassword)
+		port := jaeger.DefaultUDPSpanServerPort
+		if e := os.Getenv(envAgentPort); e != "" {
+			if value, err := strconv.ParseInt(e, 10, 0); err == nil {
+				port = int(value)
+			} else {
+				return nil, errors.Wrapf(err, "cannot parse env var %s=%s", envAgentPort, e)
+			}
+		}
+		// the side effect of this is that we are building the default value, even if none of the env vars
+		// were not explicitly passed
+		rc.LocalAgentHostPort = fmt.Sprintf("%s:%d", host, port)
 	}
-	rc.User = user
-	rc.Password = pswd
 
 	return rc, nil
 }


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves: #340 

If the two config options(JAEGER_ENDPOINT, JAEGER_AGENT_XXX) are set, the traces are sent to the endpoint using JAEGER_ENDPOINT, making the JAEGER_AGENT_XXX vars ineffective.
This is already implemented and documented in java/node client.
Also, go client doc also explains the same
```
If JAEGER_ENDPOINT is set, the client sends traces to the endpoint via HTTP, 
making the JAEGER_AGENT_HOST and JAEGER_AGENT_PORT unused. 
```
But the code just returns an error, which is different.

IMO, there is no reason just for go-client to be different. should be same.

## Short description of the changes
- Not use JAEGER_AGENT_XXX env if JAEGER_ENDPOINT env is set.
