### PR TITLE
Upgrade go version to 1.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ dist: trusty
 
 matrix:
   include:
-  - go: 1.9
+  - go: 1.11.1
     env:
     - TESTS=true
     - COVERAGE=true
-  - go: 1.9
+  - go: 1.11.1
     env:
     - CROSSDOCK=true
-  - go: 1.9
+  - go: 1.11.1
     env:
     - TESTS=true
     - USE_DEP=true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -373,7 +373,7 @@ func TestInitGlobalTracer(t *testing.T) {
 		{
 			cfg: Configuration{
 				Sampler: &SamplerConfig{
-					Type: "remote",
+					Type:                    "remote",
 					SamplingRefreshInterval: 1,
 				},
 			},

--- a/crossdock/endtoend/handler.go
+++ b/crossdock/endtoend/handler.go
@@ -38,8 +38,8 @@ var (
 	endToEndConfig = config.Configuration{
 		Disabled: false,
 		Sampler: &config.SamplerConfig{
-			Type:  defaultSamplerType,
-			Param: 1.0,
+			Type:                    defaultSamplerType,
+			Param:                   1.0,
 			SamplingRefreshInterval: 5 * time.Second,
 		},
 		Reporter: &config.ReporterConfig{

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -134,11 +134,11 @@ func TestHTTPErrorLogging(t *testing.T) {
 			URL: s.SpanURL(),
 		},
 		{ // bad URL path
-			URL: s.httpServer.URL + "/bad_suffix",
+			URL:                   s.httpServer.URL + "/bad_suffix",
 			expectErrorSubstrings: []string{"error from collector: code=404"},
 		},
 		{ // bad URL scheme
-			URL: "badscheme://localhost:10001",
+			URL:                   "badscheme://localhost:10001",
 			expectErrorSubstrings: []string{"error when flushing the buffer"},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Upgrade go version to 1.11.1

## Short description of the changes
- Upgrade go version to 1.11.1
- Fix gofmt error caused from 1.11.1
```
go fmt or license check failures, run 'make fmt'
./crossdock/endtoend/handler.go
./transport/zipkin/http_test.go
./config/config_test.go
make[1]: *** [lint] Error 1
make: *** [test-ci] Error 2
```
