### PR TITLE
Change metrics prefix to jaeger_tracer and add descriptions

### DIFF
--- a/baggage_setter_test.go
+++ b/baggage_setter_test.go
@@ -52,11 +52,11 @@ func TestTruncateBaggage(t *testing.T) {
 
 		factory.AssertCounterMetrics(t,
 			metricstest.ExpectedMetric{
-				Name:  "baggage_truncations",
+				Name:  "jaeger_tracer.baggage_truncations",
 				Value: 1,
 			},
 			metricstest.ExpectedMetric{
-				Name:  "baggage_updates",
+				Name:  "jaeger_tracer.baggage_updates",
 				Tags:  map[string]string{"result": "ok"},
 				Value: 1,
 			},
@@ -84,7 +84,7 @@ func TestInvalidBaggage(t *testing.T) {
 
 		factory.AssertCounterMetrics(t,
 			metricstest.ExpectedMetric{
-				Name:  "baggage_updates",
+				Name:  "jaeger_tracer.baggage_updates",
 				Tags:  map[string]string{"result": "err"},
 				Value: 1,
 			},

--- a/baggage_setter_test.go
+++ b/baggage_setter_test.go
@@ -52,11 +52,11 @@ func TestTruncateBaggage(t *testing.T) {
 
 		factory.AssertCounterMetrics(t,
 			metricstest.ExpectedMetric{
-				Name:  "jaeger.baggage_truncations",
+				Name:  "baggage_truncations",
 				Value: 1,
 			},
 			metricstest.ExpectedMetric{
-				Name:  "jaeger.baggage_updates",
+				Name:  "baggage_updates",
 				Tags:  map[string]string{"result": "ok"},
 				Value: 1,
 			},
@@ -84,7 +84,7 @@ func TestInvalidBaggage(t *testing.T) {
 
 		factory.AssertCounterMetrics(t,
 			metricstest.ExpectedMetric{
-				Name:  "jaeger.baggage_updates",
+				Name:  "baggage_updates",
 				Tags:  map[string]string{"result": "err"},
 				Value: 1,
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -346,7 +346,7 @@ func TestInitGlobalTracer(t *testing.T) {
 		{
 			cfg: Configuration{
 				Sampler: &SamplerConfig{
-					Type: "remote",
+					Type:                    "remote",
 					SamplingRefreshInterval: 1,
 				},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -436,7 +436,7 @@ func TestBaggageRestrictionsConfig(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 
-	metricName := "baggage_restrictions_updates"
+	metricName := "jaeger_tracer.baggage_restrictions_updates"
 	metricTags := map[string]string{"result": "err"}
 	key := metrics.GetKey(metricName, metricTags, "|", "=")
 	for i := 0; i < 100; i++ {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -346,7 +346,7 @@ func TestInitGlobalTracer(t *testing.T) {
 		{
 			cfg: Configuration{
 				Sampler: &SamplerConfig{
-					Type:                    "remote",
+					Type: "remote",
 					SamplingRefreshInterval: 1,
 				},
 			},
@@ -436,7 +436,7 @@ func TestBaggageRestrictionsConfig(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 
-	metricName := "jaeger.baggage_restrictions_updates"
+	metricName := "baggage_restrictions_updates"
 	metricTags := map[string]string{"result": "err"}
 	key := metrics.GetKey(metricName, metricTags, "|", "=")
 	for i := 0; i < 100; i++ {

--- a/internal/baggage/remote/restriction_manager_test.go
+++ b/internal/baggage/remote/restriction_manager_test.go
@@ -121,7 +121,7 @@ func TestNewRemoteRestrictionManager(t *testing.T) {
 
 			factory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name:  "jaeger.baggage_restrictions_updates",
+					Name:  "baggage_restrictions_updates",
 					Tags:  map[string]string{"result": "ok"},
 					Value: 1,
 				},
@@ -147,7 +147,7 @@ func TestDenyBaggageOnInitializationFailure(t *testing.T) {
 			)
 			require.False(t, mgr.isReady())
 
-			metricName := "jaeger.baggage_restrictions_updates"
+			metricName := "baggage_restrictions_updates"
 			metricTags := map[string]string{"result": "err"}
 			key := metrics.GetKey(metricName, metricTags, "|", "=")
 			for i := 0; i < 100; i++ {

--- a/internal/baggage/remote/restriction_manager_test.go
+++ b/internal/baggage/remote/restriction_manager_test.go
@@ -121,7 +121,7 @@ func TestNewRemoteRestrictionManager(t *testing.T) {
 
 			factory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name:  "baggage_restrictions_updates",
+					Name:  "jaeger_tracer.baggage_restrictions_updates",
 					Tags:  map[string]string{"result": "ok"},
 					Value: 1,
 				},
@@ -147,7 +147,7 @@ func TestDenyBaggageOnInitializationFailure(t *testing.T) {
 			)
 			require.False(t, mgr.isReady())
 
-			metricName := "baggage_restrictions_updates"
+			metricName := "jaeger_tracer.baggage_restrictions_updates"
 			metricTags := map[string]string{"result": "err"}
 			key := metrics.GetKey(metricName, metricTags, "|", "=")
 			for i := 0; i < 100; i++ {

--- a/internal/throttler/remote/throttler_test.go
+++ b/internal/throttler/remote/throttler_test.go
@@ -185,7 +185,7 @@ func TestRemoteThrottler_fetchCreditsErrors(t *testing.T) {
 
 			factory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name:  "throttler_updates",
+					Name:  "jaeger_tracer.throttler_updates",
 					Tags:  map[string]string{"result": "err"},
 					Value: 1,
 				})
@@ -218,7 +218,7 @@ func TestRemotelyControlledThrottler_pollManager(t *testing.T) {
 
 			throttler.refreshCredits()
 			counters, _ := factory.Snapshot()
-			counter, ok := counters["throttler_updates|result=ok"]
+			counter, ok := counters["jaeger_tracer.throttler_updates|result=ok"]
 			assert.True(t, ok)
 			assert.True(t, counter >= 1)
 		})

--- a/internal/throttler/remote/throttler_test.go
+++ b/internal/throttler/remote/throttler_test.go
@@ -185,7 +185,7 @@ func TestRemoteThrottler_fetchCreditsErrors(t *testing.T) {
 
 			factory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name:  "jaeger.throttler_updates",
+					Name:  "throttler_updates",
 					Tags:  map[string]string{"result": "err"},
 					Value: 1,
 				})
@@ -218,7 +218,7 @@ func TestRemotelyControlledThrottler_pollManager(t *testing.T) {
 
 			throttler.refreshCredits()
 			counters, _ := factory.Snapshot()
-			counter, ok := counters["jaeger.throttler_updates|result=ok"]
+			counter, ok := counters["throttler_updates|result=ok"]
 			assert.True(t, ok)
 			assert.True(t, counter >= 1)
 		})

--- a/metrics.go
+++ b/metrics.go
@@ -36,7 +36,7 @@ type Metrics struct {
 	SpansStartedSampled metrics.Counter `metric:"started_spans" tags:"sampled=y" help:"Number of sampled spans started by this tracer"`
 
 	// Number of unsampled spans started by this tracer
-	SpansStartedNotSampled metrics.Counter `metric:"started_spans" tags:"sampled=n" help:"Number of unsampled spans started by this tracer`
+	SpansStartedNotSampled metrics.Counter `metric:"started_spans" tags:"sampled=n" help:"Number of unsampled spans started by this tracer"`
 
 	// Number of spans finished by this tracer
 	SpansFinished metrics.Counter `metric:"finished_spans" help:"Number of spans finished by this tracer"`
@@ -96,7 +96,7 @@ type Metrics struct {
 // NewMetrics creates a new Metrics struct and initializes it.
 func NewMetrics(factory metrics.Factory, globalTags map[string]string) *Metrics {
 	m := &Metrics{}
-	metrics.Init(m, factory, globalTags)
+	_ = metrics.Init(m, factory, globalTags)
 	return m
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -96,7 +96,8 @@ type Metrics struct {
 // NewMetrics creates a new Metrics struct and initializes it.
 func NewMetrics(factory metrics.Factory, globalTags map[string]string) *Metrics {
 	m := &Metrics{}
-	metrics.MustInit(m, factory, globalTags)
+	// TODO the namespace "jaeger" should be configurable
+	metrics.MustInit(m, factory.Namespace(metrics.NSOptions{Name: "jaeger_tracer"}), globalTags)
 	return m
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -96,7 +96,7 @@ type Metrics struct {
 // NewMetrics creates a new Metrics struct and initializes it.
 func NewMetrics(factory metrics.Factory, globalTags map[string]string) *Metrics {
 	m := &Metrics{}
-	_ = metrics.Init(m, factory, globalTags)
+	metrics.MustInit(m, factory, globalTags)
 	return m
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -96,8 +96,7 @@ type Metrics struct {
 // NewMetrics creates a new Metrics struct and initializes it.
 func NewMetrics(factory metrics.Factory, globalTags map[string]string) *Metrics {
 	m := &Metrics{}
-	// TODO the namespace "jaeger" should be configurable (e.g. in all-in-one "jaeger-client" would make more sense)
-	metrics.MustInit(m, factory.Namespace(metrics.NSOptions{Name: "jaeger"}), globalTags)
+	metrics.Init(m, factory, globalTags)
 	return m
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -21,76 +21,76 @@ import (
 // Metrics is a container of all stats emitted by Jaeger tracer.
 type Metrics struct {
 	// Number of traces started by this tracer as sampled
-	TracesStartedSampled metrics.Counter `metric:"traces" tags:"state=started,sampled=y"`
+	TracesStartedSampled metrics.Counter `metric:"traces" tags:"state=started,sampled=y" help:"Number of traces started by this tracer as sampled"`
 
 	// Number of traces started by this tracer as not sampled
-	TracesStartedNotSampled metrics.Counter `metric:"traces" tags:"state=started,sampled=n"`
+	TracesStartedNotSampled metrics.Counter `metric:"traces" tags:"state=started,sampled=n" help:"Number of traces started by this tracer as not sampled"`
 
 	// Number of externally started sampled traces this tracer joined
-	TracesJoinedSampled metrics.Counter `metric:"traces" tags:"state=joined,sampled=y"`
+	TracesJoinedSampled metrics.Counter `metric:"traces" tags:"state=joined,sampled=y" help:"Number of externally started sampled traces this tracer joined"`
 
 	// Number of externally started not-sampled traces this tracer joined
-	TracesJoinedNotSampled metrics.Counter `metric:"traces" tags:"state=joined,sampled=n"`
+	TracesJoinedNotSampled metrics.Counter `metric:"traces" tags:"state=joined,sampled=n" help:"Number of externally started not-sampled traces this tracer joined"`
 
 	// Number of sampled spans started by this tracer
-	SpansStartedSampled metrics.Counter `metric:"started_spans" tags:"sampled=y"`
+	SpansStartedSampled metrics.Counter `metric:"started_spans" tags:"sampled=y" help:"Number of sampled spans started by this tracer"`
 
 	// Number of unsampled spans started by this tracer
-	SpansStartedNotSampled metrics.Counter `metric:"started_spans" tags:"sampled=n"`
+	SpansStartedNotSampled metrics.Counter `metric:"started_spans" tags:"sampled=n" help:"Number of unsampled spans started by this tracer`
 
 	// Number of spans finished by this tracer
-	SpansFinished metrics.Counter `metric:"finished_spans"`
+	SpansFinished metrics.Counter `metric:"finished_spans" help:"Number of spans finished by this tracer"`
 
 	// Number of errors decoding tracing context
-	DecodingErrors metrics.Counter `metric:"span_context_decoding_errors"`
+	DecodingErrors metrics.Counter `metric:"span_context_decoding_errors" help:"Number of errors decoding tracing context"`
 
 	// Number of spans successfully reported
-	ReporterSuccess metrics.Counter `metric:"reporter_spans" tags:"result=ok"`
+	ReporterSuccess metrics.Counter `metric:"reporter_spans" tags:"result=ok" help:"Number of spans successfully reported"`
 
 	// Number of spans not reported due to a Sender failure
-	ReporterFailure metrics.Counter `metric:"reporter_spans" tags:"result=err"`
+	ReporterFailure metrics.Counter `metric:"reporter_spans" tags:"result=err" help:"Number of spans not reported due to a Sender failure"`
 
 	// Number of spans dropped due to internal queue overflow
-	ReporterDropped metrics.Counter `metric:"reporter_spans" tags:"result=dropped"`
+	ReporterDropped metrics.Counter `metric:"reporter_spans" tags:"result=dropped" help:"Number of spans dropped due to internal queue overflow"`
 
 	// Current number of spans in the reporter queue
-	ReporterQueueLength metrics.Gauge `metric:"reporter_queue_length"`
+	ReporterQueueLength metrics.Gauge `metric:"reporter_queue_length" help:"Current number of spans in the reporter queue"`
 
 	// Number of times the Sampler succeeded to retrieve sampling strategy
-	SamplerRetrieved metrics.Counter `metric:"sampler_queries" tags:"result=ok"`
+	SamplerRetrieved metrics.Counter `metric:"sampler_queries" tags:"result=ok" help:"Number of times the Sampler succeeded to retrieve sampling strategy"`
 
 	// Number of times the Sampler failed to retrieve sampling strategy
-	SamplerQueryFailure metrics.Counter `metric:"sampler_queries" tags:"result=err"`
+	SamplerQueryFailure metrics.Counter `metric:"sampler_queries" tags:"result=err" help:"Number of times the Sampler failed to retrieve sampling strategy"`
 
 	// Number of times the Sampler succeeded to retrieve and update sampling strategy
-	SamplerUpdated metrics.Counter `metric:"sampler_updates" tags:"result=ok"`
+	SamplerUpdated metrics.Counter `metric:"sampler_updates" tags:"result=ok" help:"Number of times the Sampler succeeded to retrieve and update sampling strategy"`
 
 	// Number of times the Sampler failed to update sampling strategy
-	SamplerUpdateFailure metrics.Counter `metric:"sampler_updates" tags:"result=err"`
+	SamplerUpdateFailure metrics.Counter `metric:"sampler_updates" tags:"result=err" help:"Number of times the Sampler failed to update sampling strategy"`
 
 	// Number of times baggage was successfully written or updated on spans.
-	BaggageUpdateSuccess metrics.Counter `metric:"baggage_updates" tags:"result=ok"`
+	BaggageUpdateSuccess metrics.Counter `metric:"baggage_updates" tags:"result=ok" help:"Number of times baggage was successfully written or updated on spans"`
 
 	// Number of times baggage failed to write or update on spans.
-	BaggageUpdateFailure metrics.Counter `metric:"baggage_updates" tags:"result=err"`
+	BaggageUpdateFailure metrics.Counter `metric:"baggage_updates" tags:"result=err" help:"Number of times baggage failed to write or update on spans"`
 
 	// Number of times baggage was truncated as per baggage restrictions.
-	BaggageTruncate metrics.Counter `metric:"baggage_truncations"`
+	BaggageTruncate metrics.Counter `metric:"baggage_truncations" help:"Number of times baggage was truncated as per baggage restrictions"`
 
 	// Number of times baggage restrictions were successfully updated.
-	BaggageRestrictionsUpdateSuccess metrics.Counter `metric:"baggage_restrictions_updates" tags:"result=ok"`
+	BaggageRestrictionsUpdateSuccess metrics.Counter `metric:"baggage_restrictions_updates" tags:"result=ok" help:"Number of times baggage restrictions were successfully updated"`
 
 	// Number of times baggage restrictions failed to update.
-	BaggageRestrictionsUpdateFailure metrics.Counter `metric:"baggage_restrictions_updates" tags:"result=err"`
+	BaggageRestrictionsUpdateFailure metrics.Counter `metric:"baggage_restrictions_updates" tags:"result=err" help:"Number of times baggage restrictions failed to update"`
 
 	// Number of times debug spans were throttled.
-	ThrottledDebugSpans metrics.Counter `metric:"throttled_debug_spans"`
+	ThrottledDebugSpans metrics.Counter `metric:"throttled_debug_spans" help:"Number of times debug spans were throttled"`
 
 	// Number of times throttler successfully updated.
-	ThrottlerUpdateSuccess metrics.Counter `metric:"throttler_updates" tags:"result=ok"`
+	ThrottlerUpdateSuccess metrics.Counter `metric:"throttler_updates" tags:"result=ok" help:"Number of times throttler successfully updated"`
 
 	// Number of times throttler failed to update.
-	ThrottlerUpdateFailure metrics.Counter `metric:"throttler_updates" tags:"result=err"`
+	ThrottlerUpdateFailure metrics.Counter `metric:"throttler_updates" tags:"result=err" help:"Number of times throttler failed to update"`
 }
 
 // NewMetrics creates a new Metrics struct and initializes it.

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -32,14 +32,14 @@ func TestNewMetrics(t *testing.T) {
 	m.ReporterQueueLength.Update(11)
 	factory.AssertCounterMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "started_spans",
+			Name:  "jaeger_tracer.started_spans",
 			Tags:  map[string]string{"lib": "jaeger", "sampled": "y"},
 			Value: 1,
 		},
 	)
 	factory.AssertGaugeMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "reporter_queue_length",
+			Name:  "jaeger_tracer.reporter_queue_length",
 			Tags:  map[string]string{"lib": "jaeger"},
 			Value: 11,
 		},

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -32,14 +32,14 @@ func TestNewMetrics(t *testing.T) {
 	m.ReporterQueueLength.Update(11)
 	factory.AssertCounterMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "jaeger.started_spans",
+			Name:  "started_spans",
 			Tags:  map[string]string{"lib": "jaeger", "sampled": "y"},
 			Value: 1,
 		},
 	)
 	factory.AssertGaugeMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "jaeger.reporter_queue_length",
+			Name:  "reporter_queue_length",
 			Tags:  map[string]string{"lib": "jaeger"},
 			Value: 11,
 		},

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -118,10 +118,10 @@ func TestSpanPropagator(t *testing.T) {
 	}
 
 	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
-		{Name: "jaeger.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1 + 2*len(tests)},
-		{Name: "jaeger.finished_spans", Value: 1 + len(tests)},
-		{Name: "jaeger.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1},
-		{Name: "jaeger.traces", Tags: map[string]string{"state": "joined", "sampled": "y"}, Value: len(tests)},
+		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1 + 2*len(tests)},
+		{Name: "finished_spans", Value: 1 + len(tests)},
+		{Name: "traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1},
+		{Name: "traces", Tags: map[string]string{"state": "joined", "sampled": "y"}, Value: len(tests)},
 	}...)
 }
 
@@ -150,7 +150,7 @@ func TestDecodingError(t *testing.T) {
 	_, err := tracer.Extract(opentracing.HTTPHeaders, tmc)
 	assert.Error(t, err)
 
-	metricsFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{Name: "jaeger.span_context_decoding_errors", Value: 1})
+	metricsFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{Name: "span_context_decoding_errors", Value: 1})
 }
 
 func TestBaggagePropagationHTTP(t *testing.T) {
@@ -213,7 +213,7 @@ func TestJaegerBaggageHeader(t *testing.T) {
 			// ensure that traces.started counter is incremented, not traces.joined
 			metricsFactory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name: "jaeger.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+					Name: "traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
 				},
 			)
 		})
@@ -286,7 +286,7 @@ func TestDebugCorrelationID(t *testing.T) {
 			// ensure that traces.started counter is incremented, not traces.joined
 			metricsFactory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name: "jaeger.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+					Name: "traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
 				},
 			)
 		})

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -118,10 +118,10 @@ func TestSpanPropagator(t *testing.T) {
 	}
 
 	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
-		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1 + 2*len(tests)},
-		{Name: "finished_spans", Value: 1 + len(tests)},
-		{Name: "traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1},
-		{Name: "traces", Tags: map[string]string{"state": "joined", "sampled": "y"}, Value: len(tests)},
+		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1 + 2*len(tests)},
+		{Name: "jaeger_tracer.finished_spans", Value: 1 + len(tests)},
+		{Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1},
+		{Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "joined", "sampled": "y"}, Value: len(tests)},
 	}...)
 }
 
@@ -150,7 +150,7 @@ func TestDecodingError(t *testing.T) {
 	_, err := tracer.Extract(opentracing.HTTPHeaders, tmc)
 	assert.Error(t, err)
 
-	metricsFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{Name: "span_context_decoding_errors", Value: 1})
+	metricsFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{Name: "jaeger_tracer.span_context_decoding_errors", Value: 1})
 }
 
 func TestBaggagePropagationHTTP(t *testing.T) {
@@ -213,7 +213,7 @@ func TestJaegerBaggageHeader(t *testing.T) {
 			// ensure that traces.started counter is incremented, not traces.joined
 			metricsFactory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name: "traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+					Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
 				},
 			)
 		})
@@ -286,7 +286,7 @@ func TestDebugCorrelationID(t *testing.T) {
 			// ensure that traces.started counter is incremented, not traces.joined
 			metricsFactory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name: "traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+					Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
 				},
 			)
 		})

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/metricstest"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/testutils"
@@ -41,7 +41,7 @@ type reporterSuite struct {
 	serviceName    string
 	reporter       *remoteReporter
 	sender         *fakeSender
-	metricsFactory *mTestutils.Factory
+	metricsFactory *metricstest.Factory
 	logger         *log.BytesBufferLogger
 }
 
@@ -51,7 +51,7 @@ func makeReporterSuite(t *testing.T, opts ...ReporterOption) *reporterSuite {
 
 func makeReporterSuiteWithSender(t *testing.T, sender *fakeSender, opts ...ReporterOption) *reporterSuite {
 	s := &reporterSuite{
-		metricsFactory: mTestutils.NewFactory(0),
+		metricsFactory: metricstest.NewFactory(0),
 		serviceName:    "DOOP",
 		sender:         sender,
 		logger:         &log.BytesBufferLogger{},
@@ -152,12 +152,12 @@ func TestRemoteReporterDroppedSpans(t *testing.T) {
 	s.tracer.StartSpan("s2").Finish() // this span should be dropped since the queue is full
 
 	s.metricsFactory.AssertCounterMetrics(t,
-		mTestutils.ExpectedMetric{
+		metricstest.ExpectedMetric{
 			Name:  "reporter_spans",
 			Tags:  map[string]string{"result": "ok"},
 			Value: 0,
 		},
-		mTestutils.ExpectedMetric{
+		metricstest.ExpectedMetric{
 			Name:  "reporter_spans",
 			Tags:  map[string]string{"result": "dropped"},
 			Value: 1,
@@ -213,7 +213,7 @@ func testRemoteReporterWithSender(
 	senderFactory func(m *Metrics) (Transport, error),
 	getBatches func() []*j.Batch,
 ) {
-	metricsFactory := mTestutils.NewFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	metrics := NewMetrics(metricsFactory, nil)
 
 	sender, err := senderFactory(metrics)
@@ -249,7 +249,7 @@ func testRemoteReporterWithSender(
 	assert.NotNil(t, tag)
 	assert.Equal(t, "downstream", *tag.VStr)
 
-	metricsFactory.AssertCounterMetrics(t, []mTestutils.ExpectedMetric{
+	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 		{Name: "reporter_spans", Tags: map[string]string{"result": "ok"}, Value: 1},
 		{Name: "reporter_spans", Tags: map[string]string{"result": "err"}, Value: 0},
 	}...)

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/metricstest"
+	mTestutils "github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/testutils"
@@ -41,7 +41,7 @@ type reporterSuite struct {
 	serviceName    string
 	reporter       *remoteReporter
 	sender         *fakeSender
-	metricsFactory *metricstest.Factory
+	metricsFactory *mTestutils.Factory
 	logger         *log.BytesBufferLogger
 }
 
@@ -51,7 +51,7 @@ func makeReporterSuite(t *testing.T, opts ...ReporterOption) *reporterSuite {
 
 func makeReporterSuiteWithSender(t *testing.T, sender *fakeSender, opts ...ReporterOption) *reporterSuite {
 	s := &reporterSuite{
-		metricsFactory: metricstest.NewFactory(0),
+		metricsFactory: mTestutils.NewFactory(0),
 		serviceName:    "DOOP",
 		sender:         sender,
 		logger:         &log.BytesBufferLogger{},
@@ -116,7 +116,7 @@ func TestRemoteReporterAppendAndPeriodicFlush(t *testing.T) {
 	s.sender.assertBufferedSpans(t, 1)
 	// here we wait for periodic flush to occur
 	s.sender.assertFlushedSpans(t, 1)
-	s.assertCounter(t, "jaeger.reporter_spans", map[string]string{"result": "ok"}, 1)
+	s.assertCounter(t, "reporter_spans", map[string]string{"result": "ok"}, 1)
 }
 
 func TestRemoteReporterFlushViaAppend(t *testing.T) {
@@ -127,8 +127,8 @@ func TestRemoteReporterFlushViaAppend(t *testing.T) {
 	s.sender.assertFlushedSpans(t, 2)
 	s.tracer.StartSpan("sp3").Finish()
 	s.sender.assertBufferedSpans(t, 1)
-	s.assertCounter(t, "jaeger.reporter_spans", map[string]string{"result": "ok"}, 2)
-	s.assertCounter(t, "jaeger.reporter_spans", map[string]string{"result": "err"}, 0)
+	s.assertCounter(t, "reporter_spans", map[string]string{"result": "ok"}, 2)
+	s.assertCounter(t, "reporter_spans", map[string]string{"result": "err"}, 0)
 }
 
 func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
@@ -137,8 +137,8 @@ func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
 	s.tracer.StartSpan("sp2").Finish()
 	s.sender.assertFlushedSpans(t, 2)
 	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\n")
-	s.assertCounter(t, "jaeger.reporter_spans", map[string]string{"result": "err"}, 2)
-	s.assertCounter(t, "jaeger.reporter_spans", map[string]string{"result": "ok"}, 0)
+	s.assertCounter(t, "reporter_spans", map[string]string{"result": "err"}, 2)
+	s.assertCounter(t, "reporter_spans", map[string]string{"result": "ok"}, 0)
 	s.close() // causes explicit flush that also fails with the same error
 	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\nERROR: error when flushing the buffer: flush error\n")
 }
@@ -152,13 +152,13 @@ func TestRemoteReporterDroppedSpans(t *testing.T) {
 	s.tracer.StartSpan("s2").Finish() // this span should be dropped since the queue is full
 
 	s.metricsFactory.AssertCounterMetrics(t,
-		metricstest.ExpectedMetric{
-			Name:  "jaeger.reporter_spans",
+		mTestutils.ExpectedMetric{
+			Name:  "reporter_spans",
 			Tags:  map[string]string{"result": "ok"},
 			Value: 0,
 		},
-		metricstest.ExpectedMetric{
-			Name:  "jaeger.reporter_spans",
+		mTestutils.ExpectedMetric{
+			Name:  "reporter_spans",
 			Tags:  map[string]string{"result": "dropped"},
 			Value: 1,
 		},
@@ -213,7 +213,7 @@ func testRemoteReporterWithSender(
 	senderFactory func(m *Metrics) (Transport, error),
 	getBatches func() []*j.Batch,
 ) {
-	metricsFactory := metricstest.NewFactory(0)
+	metricsFactory := mTestutils.NewFactory(0)
 	metrics := NewMetrics(metricsFactory, nil)
 
 	sender, err := senderFactory(metrics)
@@ -249,9 +249,9 @@ func testRemoteReporterWithSender(
 	assert.NotNil(t, tag)
 	assert.Equal(t, "downstream", *tag.VStr)
 
-	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
-		{Name: "jaeger.reporter_spans", Tags: map[string]string{"result": "ok"}, Value: 1},
-		{Name: "jaeger.reporter_spans", Tags: map[string]string{"result": "err"}, Value: 0},
+	metricsFactory.AssertCounterMetrics(t, []mTestutils.ExpectedMetric{
+		{Name: "reporter_spans", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "reporter_spans", Tags: map[string]string{"result": "err"}, Value: 0},
 	}...)
 }
 

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -116,7 +116,7 @@ func TestRemoteReporterAppendAndPeriodicFlush(t *testing.T) {
 	s.sender.assertBufferedSpans(t, 1)
 	// here we wait for periodic flush to occur
 	s.sender.assertFlushedSpans(t, 1)
-	s.assertCounter(t, "reporter_spans", map[string]string{"result": "ok"}, 1)
+	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "ok"}, 1)
 }
 
 func TestRemoteReporterFlushViaAppend(t *testing.T) {
@@ -127,8 +127,8 @@ func TestRemoteReporterFlushViaAppend(t *testing.T) {
 	s.sender.assertFlushedSpans(t, 2)
 	s.tracer.StartSpan("sp3").Finish()
 	s.sender.assertBufferedSpans(t, 1)
-	s.assertCounter(t, "reporter_spans", map[string]string{"result": "ok"}, 2)
-	s.assertCounter(t, "reporter_spans", map[string]string{"result": "err"}, 0)
+	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "ok"}, 2)
+	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "err"}, 0)
 }
 
 func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
@@ -137,8 +137,8 @@ func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
 	s.tracer.StartSpan("sp2").Finish()
 	s.sender.assertFlushedSpans(t, 2)
 	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\n")
-	s.assertCounter(t, "reporter_spans", map[string]string{"result": "err"}, 2)
-	s.assertCounter(t, "reporter_spans", map[string]string{"result": "ok"}, 0)
+	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "err"}, 2)
+	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "ok"}, 0)
 	s.close() // causes explicit flush that also fails with the same error
 	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\nERROR: error when flushing the buffer: flush error\n")
 }
@@ -153,12 +153,12 @@ func TestRemoteReporterDroppedSpans(t *testing.T) {
 
 	s.metricsFactory.AssertCounterMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "reporter_spans",
+			Name:  "jaeger_tracer.reporter_spans",
 			Tags:  map[string]string{"result": "ok"},
 			Value: 0,
 		},
 		metricstest.ExpectedMetric{
-			Name:  "reporter_spans",
+			Name:  "jaeger_tracer.reporter_spans",
 			Tags:  map[string]string{"result": "dropped"},
 			Value: 1,
 		},
@@ -250,8 +250,8 @@ func testRemoteReporterWithSender(
 	assert.Equal(t, "downstream", *tag.VStr)
 
 	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
-		{Name: "reporter_spans", Tags: map[string]string{"result": "ok"}, Value: 1},
-		{Name: "reporter_spans", Tags: map[string]string{"result": "err"}, Value: 0},
+		{Name: "jaeger_tracer.reporter_spans", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "jaeger_tracer.reporter_spans", Tags: map[string]string{"result": "err"}, Value: 0},
 	}...)
 }
 

--- a/rpcmetrics/observer_test.go
+++ b/rpcmetrics/observer_test.go
@@ -21,14 +21,14 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics/metricstest"
+	u "github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/opentracing/opentracing-go/ext"
 	jaeger "github.com/uber/jaeger-client-go"
 )
 
 func ExampleObserver() {
-	metricsFactory := metricstest.NewFactory(0)
+	metricsFactory := u.NewFactory(0)
 	metricsObserver := NewObserver(
 		metricsFactory,
 		DefaultNameNormalizer,
@@ -53,14 +53,14 @@ func ExampleObserver() {
 }
 
 type testTracer struct {
-	metrics *metricstest.Factory
+	metrics *u.Factory
 	tracer  opentracing.Tracer
 }
 
 func withTestTracer(runTest func(tt *testTracer)) {
 	sampler := jaeger.NewConstSampler(true)
 	reporter := jaeger.NewInMemoryReporter()
-	metrics := metricstest.NewFactory(time.Minute)
+	metrics := u.NewFactory(time.Minute)
 	observer := NewObserver(metrics, DefaultNameNormalizer)
 	tracer, closer := jaeger.NewTracer(
 		"test",
@@ -110,11 +110,11 @@ func TestObserver(t *testing.T) {
 		}
 
 		testTracer.metrics.AssertCounterMetrics(t,
-			metricstest.ExpectedMetric{Name: "requests", Tags: endpointTags("local-span", "error", "false"), Value: 0},
-			metricstest.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user", "error", "false"), Value: 1},
-			metricstest.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user", "error", "true"), Value: 1},
-			metricstest.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user-override", "error", "false"), Value: 1},
-			metricstest.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user-client", "error", "false"), Value: 0},
+			u.ExpectedMetric{Name: "requests", Tags: endpointTags("local-span", "error", "false"), Value: 0},
+			u.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user", "error", "false"), Value: 1},
+			u.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user", "error", "true"), Value: 1},
+			u.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user-override", "error", "false"), Value: 1},
+			u.ExpectedMetric{Name: "requests", Tags: endpointTags("get-user-client", "error", "false"), Value: 0},
 		)
 		// TODO something wrong with string generation, .P99 should not be appended to the tag
 		// as a result we cannot use u.AssertGaugeMetrics
@@ -128,17 +128,17 @@ func TestTags(t *testing.T) {
 	type tagTestCase struct {
 		key     string
 		value   interface{}
-		metrics []metricstest.ExpectedMetric
+		metrics []u.ExpectedMetric
 	}
 
 	testCases := []tagTestCase{
-		{key: "something", value: 42, metrics: []metricstest.ExpectedMetric{
+		{key: "something", value: 42, metrics: []u.ExpectedMetric{
 			{Name: "requests", Value: 1, Tags: tags("error", "false")},
 		}},
-		{key: "error", value: true, metrics: []metricstest.ExpectedMetric{
+		{key: "error", value: true, metrics: []u.ExpectedMetric{
 			{Name: "requests", Value: 1, Tags: tags("error", "true")},
 		}},
-		{key: "error", value: "true", metrics: []metricstest.ExpectedMetric{
+		{key: "error", value: "true", metrics: []u.ExpectedMetric{
 			{Name: "requests", Value: 1, Tags: tags("error", "true")},
 		}},
 	}
@@ -151,7 +151,7 @@ func TestTags(t *testing.T) {
 		}
 		for _, v := range values {
 			testCases = append(testCases, tagTestCase{
-				key: "http.status_code", value: v, metrics: []metricstest.ExpectedMetric{
+				key: "http.status_code", value: v, metrics: []u.ExpectedMetric{
 					{Name: "http_requests", Value: 1, Tags: tags("status_code", fmt.Sprintf("%dxx", i))},
 				},
 			})

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics/metricstest"
+	mTestutils "github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/testutils"
@@ -284,11 +284,11 @@ func TestAdaptiveSamplerUpdate(t *testing.T) {
 	assert.Len(t, sampler.samplers, 2)
 }
 
-func initAgent(t *testing.T) (*testutils.MockAgent, *RemotelyControlledSampler, *metricstest.Factory) {
+func initAgent(t *testing.T) (*testutils.MockAgent, *RemotelyControlledSampler, *mTestutils.Factory) {
 	agent, err := testutils.StartMockAgent()
 	require.NoError(t, err)
 
-	metricsFactory := metricstest.NewFactory(0)
+	metricsFactory := mTestutils.NewFactory(0)
 	metrics := NewMetrics(metricsFactory, nil)
 
 	initialSampler, _ := NewProbabilisticSampler(0.001)
@@ -316,9 +316,9 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	agent.AddSamplingStrategy("client app",
 		getSamplingStrategyResponse(sampling.SamplingStrategyType_PROBABILISTIC, testDefaultSamplingProbability))
 	remoteSampler.updateSampler()
-	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
-		{Name: "jaeger.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
-		{Name: "jaeger.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
+	metricsFactory.AssertCounterMetrics(t, []mTestutils.ExpectedMetric{
+		{Name: "sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
 	}...)
 	s1, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
@@ -427,8 +427,8 @@ func TestRemotelyControlledSampler_updateSampler(t *testing.T) {
 			sampler.updateSampler()
 
 			metricsFactory.AssertCounterMetrics(t,
-				metricstest.ExpectedMetric{
-					Name: "jaeger.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1,
+				mTestutils.ExpectedMetric{
+					Name: "sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1,
 				},
 			)
 
@@ -485,7 +485,7 @@ func TestSamplerQueryError(t *testing.T) {
 	assert.Equal(t, initSampler, sampler.sampler, "Sampler should not have been updated due to query error")
 
 	metricsFactory.AssertCounterMetrics(t,
-		metricstest.ExpectedMetric{Name: "jaeger.sampler_queries", Tags: map[string]string{"result": "err"}, Value: 1},
+		mTestutils.ExpectedMetric{Name: "sampler_queries", Tags: map[string]string{"result": "err"}, Value: 1},
 	)
 }
 
@@ -538,8 +538,8 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 	remoteSampler.updateSampler()
 
 	metricsFactory.AssertCounterMetrics(t,
-		metricstest.ExpectedMetric{Name: "jaeger.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 3},
-		metricstest.ExpectedMetric{Name: "jaeger.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 3},
+		mTestutils.ExpectedMetric{Name: "sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 3},
+		mTestutils.ExpectedMetric{Name: "sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 3},
 	)
 }
 

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -317,8 +317,8 @@ func TestRemotelyControlledSampler(t *testing.T) {
 		getSamplingStrategyResponse(sampling.SamplingStrategyType_PROBABILISTIC, testDefaultSamplingProbability))
 	remoteSampler.updateSampler()
 	metricsFactory.AssertCounterMetrics(t, []mTestutils.ExpectedMetric{
-		{Name: "sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
-		{Name: "sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "jaeger_tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "jaeger_tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
 	}...)
 	s1, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
@@ -428,7 +428,7 @@ func TestRemotelyControlledSampler_updateSampler(t *testing.T) {
 
 			metricsFactory.AssertCounterMetrics(t,
 				mTestutils.ExpectedMetric{
-					Name: "sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1,
+					Name: "jaeger_tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1,
 				},
 			)
 
@@ -485,7 +485,7 @@ func TestSamplerQueryError(t *testing.T) {
 	assert.Equal(t, initSampler, sampler.sampler, "Sampler should not have been updated due to query error")
 
 	metricsFactory.AssertCounterMetrics(t,
-		mTestutils.ExpectedMetric{Name: "sampler_queries", Tags: map[string]string{"result": "err"}, Value: 1},
+		mTestutils.ExpectedMetric{Name: "jaeger_tracer.sampler_queries", Tags: map[string]string{"result": "err"}, Value: 1},
 	)
 }
 
@@ -538,8 +538,8 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 	remoteSampler.updateSampler()
 
 	metricsFactory.AssertCounterMetrics(t,
-		mTestutils.ExpectedMetric{Name: "sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 3},
-		mTestutils.ExpectedMetric{Name: "sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 3},
+		mTestutils.ExpectedMetric{Name: "jaeger_tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 3},
+		mTestutils.ExpectedMetric{Name: "jaeger_tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 3},
 	)
 }
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -91,9 +91,9 @@ func (s *tracerSuite) TestBeginRootSpan() {
 	s.NotNil(ss.duration)
 
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "finished_spans", Value: 1},
-		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1},
-		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "jaeger_tracer.finished_spans", Value: 1},
+		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1},
+		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
 	}...)
 }
 
@@ -114,9 +114,9 @@ func (s *tracerSuite) TestStartChildSpan() {
 	s.NotNil(sp2.(*Span).duration)
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
-		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
-		{Name: "finished_spans", Value: 2},
+		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
+		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "jaeger_tracer.finished_spans", Value: 2},
 	}...)
 }
 
@@ -145,9 +145,9 @@ func (s *tracerSuite) TestStartSpanWithMultipleReferences() {
 	sp2.Finish()
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 4},
-		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 3},
-		{Name: "finished_spans", Value: 4},
+		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 4},
+		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 3},
+		{Name: "jaeger_tracer.finished_spans", Value: 4},
 	}...)
 	assert.Len(s.T(), sp4.(*Span).references, 3)
 }
@@ -165,9 +165,9 @@ func (s *tracerSuite) TestStartSpanWithOnlyFollowFromReference() {
 	s.NotNil(sp2.(*Span).duration)
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
-		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
-		{Name: "finished_spans", Value: 2},
+		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
+		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "jaeger_tracer.finished_spans", Value: 2},
 	}...)
 	assert.Len(s.T(), sp2.(*Span).references, 1)
 }
@@ -195,10 +195,10 @@ func (s *tracerSuite) TestTraceStartedOrJoinedMetrics() {
 		s.Equal(test.sampled, sp2.Context().(SpanContext).IsSampled())
 
 		s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-			{Name: "started_spans", Tags: map[string]string{"sampled": test.label}, Value: 3},
-			{Name: "finished_spans", Value: 3},
-			{Name: "traces", Tags: map[string]string{"sampled": test.label, "state": "started"}, Value: 1},
-			{Name: "traces", Tags: map[string]string{"sampled": test.label, "state": "joined"}, Value: 1},
+			{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": test.label}, Value: 3},
+			{Name: "jaeger_tracer.finished_spans", Value: 3},
+			{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": test.label, "state": "started"}, Value: 1},
+			{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": test.label, "state": "joined"}, Value: 1},
 		}...)
 	}
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -91,9 +91,9 @@ func (s *tracerSuite) TestBeginRootSpan() {
 	s.NotNil(ss.duration)
 
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger.finished_spans", Value: 1},
-		{Name: "jaeger.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1},
-		{Name: "jaeger.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "finished_spans", Value: 1},
+		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1},
+		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
 	}...)
 }
 
@@ -114,9 +114,9 @@ func (s *tracerSuite) TestStartChildSpan() {
 	s.NotNil(sp2.(*Span).duration)
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
-		{Name: "jaeger.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
-		{Name: "jaeger.finished_spans", Value: 2},
+		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
+		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "finished_spans", Value: 2},
 	}...)
 }
 
@@ -145,9 +145,9 @@ func (s *tracerSuite) TestStartSpanWithMultipleReferences() {
 	sp2.Finish()
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 4},
-		{Name: "jaeger.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 3},
-		{Name: "jaeger.finished_spans", Value: 4},
+		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 4},
+		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 3},
+		{Name: "finished_spans", Value: 4},
 	}...)
 	assert.Len(s.T(), sp4.(*Span).references, 3)
 }
@@ -165,9 +165,9 @@ func (s *tracerSuite) TestStartSpanWithOnlyFollowFromReference() {
 	s.NotNil(sp2.(*Span).duration)
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
-		{Name: "jaeger.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
-		{Name: "jaeger.finished_spans", Value: 2},
+		{Name: "started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
+		{Name: "traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "finished_spans", Value: 2},
 	}...)
 	assert.Len(s.T(), sp2.(*Span).references, 1)
 }
@@ -195,10 +195,10 @@ func (s *tracerSuite) TestTraceStartedOrJoinedMetrics() {
 		s.Equal(test.sampled, sp2.Context().(SpanContext).IsSampled())
 
 		s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-			{Name: "jaeger.started_spans", Tags: map[string]string{"sampled": test.label}, Value: 3},
-			{Name: "jaeger.finished_spans", Value: 3},
-			{Name: "jaeger.traces", Tags: map[string]string{"sampled": test.label, "state": "started"}, Value: 1},
-			{Name: "jaeger.traces", Tags: map[string]string{"sampled": test.label, "state": "joined"}, Value: 1},
+			{Name: "started_spans", Tags: map[string]string{"sampled": test.label}, Value: 3},
+			{Name: "finished_spans", Value: 3},
+			{Name: "traces", Tags: map[string]string{"sampled": test.label, "state": "started"}, Value: 1},
+			{Name: "traces", Tags: map[string]string{"sampled": test.label, "state": "joined"}, Value: 1},
 		}...)
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Normalisation of the metric names used across the Jaeger tracers implemented in different languages as discussed in jaegertracing/jaeger#572.

## Short description of the changes
As discussed [here](https://github.com/jaegertracing/jaeger/issues/572#issuecomment-426980837), the Go client metric names have been changed so that the `jaeger_client_jaeger_<metricName>` format (reported by Go client in jaeger-query) can now be controlled by the application - and therefore a convention such as `jaeger_tracer_<metricName>` can be adopted.

The other part of the change relates to the `_total` suffix on counter metrics reported to Prometheus. This fix has been applied to `jaeger-lib` and a snapshot version is currently referenced in the `glide.lock` file.

QUESTION: Should this PR wait for a released version of `jaeger-lib` before being merged?

Not sure what the process is for updating the `Gopkg.lock`? There are no instructions in `CONTRIBUTING.md` about running `dep ensure`.

Signed-off-by: Gary Brown <gary@brownuk.com>
