### PR TITLE
Resolves #344: Run tests with N-1 version of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ matrix:
     env:
     - TESTS=true
     - USE_DEP=true
+  - go: 1.10.5
+    env:
+    - TESTS=true
+    - USE_DEP=true
+    - CI_SKIP_LINT=true
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -113,5 +113,8 @@ install-ci: install-dep-ci install
 .PHONY: test-ci
 test-ci:
 	@./scripts/cover.sh $(shell go list $(PACKAGES))
+ifeq ($(CI_SKIP_LINT),true)
+	echo 'skipping lint'
+else
 	make lint
-
+endif


### PR DESCRIPTION
Changes travis config to run another matrix step with Go N-1 version, but exclude running lint/fmt because those are likely to break betwen versions.