### PR TITLE
Fix crossdock endtoend by responding to GenerateTraces request

### DIFF
--- a/crossdock/endtoend/handler.go
+++ b/crossdock/endtoend/handler.go
@@ -138,7 +138,10 @@ func (h *Handler) GenerateTraces(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Tracer is not initialized", http.StatusInternalServerError)
 		return
 	}
+	log.Printf("Received GenerateTraces request: %+v\n", req)
 	generateTraces(tracer, &req)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Success"))
 }
 
 func generateTraces(tracer opentracing.Tracer, r *traceRequest) {

--- a/crossdock/endtoend/handler.go
+++ b/crossdock/endtoend/handler.go
@@ -141,7 +141,7 @@ func (h *Handler) GenerateTraces(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Received GenerateTraces request: %+v\n", req)
 	generateTraces(tracer, &req)
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("Success"))
+	_, _ = w.Write([]byte("Success"))
 }
 
 func generateTraces(tracer opentracing.Tracer, r *traceRequest) {


### PR DESCRIPTION
Signed-off-by: Isaac Hier <ihier@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Relates to https://github.com/jaegertracing/jaeger/issues/1191 and part of https://github.com/jaegertracing/jaeger/pull/1207 fix.

## Short description of the changes
- Respond to HTTP request in GenerateTraces to avoid timeout in crossdock test.
