### PR TITLE
zipkin: make extractor also accept "true" for the x-b3-sampled header

### DIFF
--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -75,7 +75,7 @@ func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, er
 			parentID, err = strconv.ParseUint(value, 16, 64)
 		} else if key == "x-b3-spanid" {
 			spanID, err = strconv.ParseUint(value, 16, 64)
-		} else if key == "x-b3-sampled" && value == "1" {
+		} else if key == "x-b3-sampled" && (value == "1" || value == "true") {
 			sampled = true
 		}
 		return err

--- a/zipkin/propagation_test.go
+++ b/zipkin/propagation_test.go
@@ -46,6 +46,17 @@ var (
 		"x-b3-parentspanid": "1",
 		"x-b3-sampled":      "0",
 	}
+	rootSampledBooleanHeader = opentracing.TextMapCarrier{
+		"x-b3-traceid": "1",
+		"x-b3-spanid":  "2",
+		"x-b3-sampled": "true",
+	}
+	nonRootSampledBooleanHeader = opentracing.TextMapCarrier{
+		"x-b3-traceid":      "1",
+		"x-b3-spanid":       "2",
+		"x-b3-parentspanid": "1",
+		"x-b3-sampled":      "true",
+	}
 	invalidHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid":      "jdkafhsd",
 		"x-b3-spanid":       "afsdfsdf",
@@ -89,6 +100,18 @@ func TestExtractorNonRootNonSampled(t *testing.T) {
 	ctx, err := propagator.Extract(nonRootNonSampledHeader)
 	assert.Nil(t, err)
 	assert.EqualValues(t, nonRootNonSampled, ctx)
+}
+
+func TestExtractorRootSampledBoolean(t *testing.T) {
+	ctx, err := propagator.Extract(rootSampledBooleanHeader)
+	assert.Nil(t, err)
+	assert.EqualValues(t, rootSampled, ctx)
+}
+
+func TestExtractorNonRootSampledBoolean(t *testing.T) {
+	ctx, err := propagator.Extract(nonRootSampledBooleanHeader)
+	assert.Nil(t, err)
+	assert.EqualValues(t, nonRootSampled, ctx)
 }
 
 func TestInjectorRootSampled(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

This PR is addressing issue https://github.com/jaegertracing/jaeger-client-go/issues/355.

## Short description of the changes

Make the zipkin propagator returned by `zipkin.NewZipkinB3HTTPHeaderPropagator()` accept `x-b3-sampled` with a value of `"true"`, not only `"1"` for interoperability with other frameworks that send the value in this format.

Also add relevant tests.