### PR TITLE
Avoid defer when generating random number

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -132,8 +132,9 @@ func NewTracer(
 
 		t.randomNumber = func() uint64 {
 			generator := pool.Get().(rand.Source)
-			defer pool.Put(generator)
-			return uint64(generator.Int63())
+			number := uint64(generator.Int63())
+			pool.Put(generator)
+			return number
 		}
 	}
 	if t.timeNow == nil {


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Remove `defer` used in generating random number, as recommended by @mandarjog here: https://github.com/jaegertracing/jaeger-client-go/commit/a9d03b8e10febae4d48d348612750db7e74517f8#r31655784

## Short description of the changes
Instead of putting generator back in pool using defer, do it explicitly.
