### PR TITLE
Change default metric namespace to use relevant separator for the met…

### DIFF
--- a/baggage_setter_test.go
+++ b/baggage_setter_test.go
@@ -52,11 +52,11 @@ func TestTruncateBaggage(t *testing.T) {
 
 		factory.AssertCounterMetrics(t,
 			metricstest.ExpectedMetric{
-				Name:  "jaeger_tracer.baggage_truncations",
+				Name:  "jaeger.tracer.baggage_truncations",
 				Value: 1,
 			},
 			metricstest.ExpectedMetric{
-				Name:  "jaeger_tracer.baggage_updates",
+				Name:  "jaeger.tracer.baggage_updates",
 				Tags:  map[string]string{"result": "ok"},
 				Value: 1,
 			},
@@ -84,7 +84,7 @@ func TestInvalidBaggage(t *testing.T) {
 
 		factory.AssertCounterMetrics(t,
 			metricstest.ExpectedMetric{
-				Name:  "jaeger_tracer.baggage_updates",
+				Name:  "jaeger.tracer.baggage_updates",
 				Tags:  map[string]string{"result": "err"},
 				Value: 1,
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -436,7 +436,7 @@ func TestBaggageRestrictionsConfig(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 
-	metricName := "jaeger_tracer.baggage_restrictions_updates"
+	metricName := "jaeger.tracer.baggage_restrictions_updates"
 	metricTags := map[string]string{"result": "err"}
 	key := metrics.GetKey(metricName, metricTags, "|", "=")
 	for i := 0; i < 100; i++ {

--- a/internal/baggage/remote/restriction_manager_test.go
+++ b/internal/baggage/remote/restriction_manager_test.go
@@ -121,7 +121,7 @@ func TestNewRemoteRestrictionManager(t *testing.T) {
 
 			factory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name:  "jaeger_tracer.baggage_restrictions_updates",
+					Name:  "jaeger.tracer.baggage_restrictions_updates",
 					Tags:  map[string]string{"result": "ok"},
 					Value: 1,
 				},
@@ -147,7 +147,7 @@ func TestDenyBaggageOnInitializationFailure(t *testing.T) {
 			)
 			require.False(t, mgr.isReady())
 
-			metricName := "jaeger_tracer.baggage_restrictions_updates"
+			metricName := "jaeger.tracer.baggage_restrictions_updates"
 			metricTags := map[string]string{"result": "err"}
 			key := metrics.GetKey(metricName, metricTags, "|", "=")
 			for i := 0; i < 100; i++ {

--- a/internal/throttler/remote/throttler_test.go
+++ b/internal/throttler/remote/throttler_test.go
@@ -185,7 +185,7 @@ func TestRemoteThrottler_fetchCreditsErrors(t *testing.T) {
 
 			factory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name:  "jaeger_tracer.throttler_updates",
+					Name:  "jaeger.tracer.throttler_updates",
 					Tags:  map[string]string{"result": "err"},
 					Value: 1,
 				})
@@ -218,7 +218,7 @@ func TestRemotelyControlledThrottler_pollManager(t *testing.T) {
 
 			throttler.refreshCredits()
 			counters, _ := factory.Snapshot()
-			counter, ok := counters["jaeger_tracer.throttler_updates|result=ok"]
+			counter, ok := counters["jaeger.tracer.throttler_updates|result=ok"]
 			assert.True(t, ok)
 			assert.True(t, counter >= 1)
 		})

--- a/metrics.go
+++ b/metrics.go
@@ -97,7 +97,7 @@ type Metrics struct {
 func NewMetrics(factory metrics.Factory, globalTags map[string]string) *Metrics {
 	m := &Metrics{}
 	// TODO the namespace "jaeger" should be configurable
-	metrics.MustInit(m, factory.Namespace(metrics.NSOptions{Name: "jaeger_tracer"}), globalTags)
+	metrics.MustInit(m, factory.Namespace(metrics.NSOptions{Name: "jaeger"}).Namespace(metrics.NSOptions{Name: "tracer"}), globalTags)
 	return m
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -32,14 +32,14 @@ func TestNewMetrics(t *testing.T) {
 	m.ReporterQueueLength.Update(11)
 	factory.AssertCounterMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "jaeger_tracer.started_spans",
+			Name:  "jaeger.tracer.started_spans",
 			Tags:  map[string]string{"lib": "jaeger", "sampled": "y"},
 			Value: 1,
 		},
 	)
 	factory.AssertGaugeMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "jaeger_tracer.reporter_queue_length",
+			Name:  "jaeger.tracer.reporter_queue_length",
 			Tags:  map[string]string{"lib": "jaeger"},
 			Value: 11,
 		},

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -118,10 +118,10 @@ func TestSpanPropagator(t *testing.T) {
 	}
 
 	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
-		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1 + 2*len(tests)},
-		{Name: "jaeger_tracer.finished_spans", Value: 1 + len(tests)},
-		{Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1},
-		{Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "joined", "sampled": "y"}, Value: len(tests)},
+		{Name: "jaeger.tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1 + 2*len(tests)},
+		{Name: "jaeger.tracer.finished_spans", Value: 1 + len(tests)},
+		{Name: "jaeger.tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1},
+		{Name: "jaeger.tracer.traces", Tags: map[string]string{"state": "joined", "sampled": "y"}, Value: len(tests)},
 	}...)
 }
 
@@ -150,7 +150,7 @@ func TestDecodingError(t *testing.T) {
 	_, err := tracer.Extract(opentracing.HTTPHeaders, tmc)
 	assert.Error(t, err)
 
-	metricsFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{Name: "jaeger_tracer.span_context_decoding_errors", Value: 1})
+	metricsFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{Name: "jaeger.tracer.span_context_decoding_errors", Value: 1})
 }
 
 func TestBaggagePropagationHTTP(t *testing.T) {
@@ -213,7 +213,7 @@ func TestJaegerBaggageHeader(t *testing.T) {
 			// ensure that traces.started counter is incremented, not traces.joined
 			metricsFactory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+					Name: "jaeger.tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
 				},
 			)
 		})
@@ -286,7 +286,7 @@ func TestDebugCorrelationID(t *testing.T) {
 			// ensure that traces.started counter is incremented, not traces.joined
 			metricsFactory.AssertCounterMetrics(t,
 				metricstest.ExpectedMetric{
-					Name: "jaeger_tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
+					Name: "jaeger.tracer.traces", Tags: map[string]string{"state": "started", "sampled": "y"}, Value: 1,
 				},
 			)
 		})

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -116,7 +116,7 @@ func TestRemoteReporterAppendAndPeriodicFlush(t *testing.T) {
 	s.sender.assertBufferedSpans(t, 1)
 	// here we wait for periodic flush to occur
 	s.sender.assertFlushedSpans(t, 1)
-	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "ok"}, 1)
+	s.assertCounter(t, "jaeger.tracer.reporter_spans", map[string]string{"result": "ok"}, 1)
 }
 
 func TestRemoteReporterFlushViaAppend(t *testing.T) {
@@ -127,8 +127,8 @@ func TestRemoteReporterFlushViaAppend(t *testing.T) {
 	s.sender.assertFlushedSpans(t, 2)
 	s.tracer.StartSpan("sp3").Finish()
 	s.sender.assertBufferedSpans(t, 1)
-	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "ok"}, 2)
-	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "err"}, 0)
+	s.assertCounter(t, "jaeger.tracer.reporter_spans", map[string]string{"result": "ok"}, 2)
+	s.assertCounter(t, "jaeger.tracer.reporter_spans", map[string]string{"result": "err"}, 0)
 }
 
 func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
@@ -137,8 +137,8 @@ func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
 	s.tracer.StartSpan("sp2").Finish()
 	s.sender.assertFlushedSpans(t, 2)
 	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\n")
-	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "err"}, 2)
-	s.assertCounter(t, "jaeger_tracer.reporter_spans", map[string]string{"result": "ok"}, 0)
+	s.assertCounter(t, "jaeger.tracer.reporter_spans", map[string]string{"result": "err"}, 2)
+	s.assertCounter(t, "jaeger.tracer.reporter_spans", map[string]string{"result": "ok"}, 0)
 	s.close() // causes explicit flush that also fails with the same error
 	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\nERROR: error when flushing the buffer: flush error\n")
 }
@@ -153,12 +153,12 @@ func TestRemoteReporterDroppedSpans(t *testing.T) {
 
 	s.metricsFactory.AssertCounterMetrics(t,
 		metricstest.ExpectedMetric{
-			Name:  "jaeger_tracer.reporter_spans",
+			Name:  "jaeger.tracer.reporter_spans",
 			Tags:  map[string]string{"result": "ok"},
 			Value: 0,
 		},
 		metricstest.ExpectedMetric{
-			Name:  "jaeger_tracer.reporter_spans",
+			Name:  "jaeger.tracer.reporter_spans",
 			Tags:  map[string]string{"result": "dropped"},
 			Value: 1,
 		},
@@ -250,8 +250,8 @@ func testRemoteReporterWithSender(
 	assert.Equal(t, "downstream", *tag.VStr)
 
 	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
-		{Name: "jaeger_tracer.reporter_spans", Tags: map[string]string{"result": "ok"}, Value: 1},
-		{Name: "jaeger_tracer.reporter_spans", Tags: map[string]string{"result": "err"}, Value: 0},
+		{Name: "jaeger.tracer.reporter_spans", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "jaeger.tracer.reporter_spans", Tags: map[string]string{"result": "err"}, Value: 0},
 	}...)
 }
 

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -317,8 +317,8 @@ func TestRemotelyControlledSampler(t *testing.T) {
 		getSamplingStrategyResponse(sampling.SamplingStrategyType_PROBABILISTIC, testDefaultSamplingProbability))
 	remoteSampler.updateSampler()
 	metricsFactory.AssertCounterMetrics(t, []mTestutils.ExpectedMetric{
-		{Name: "jaeger_tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
-		{Name: "jaeger_tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "jaeger.tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
+		{Name: "jaeger.tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
 	}...)
 	s1, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
@@ -428,7 +428,7 @@ func TestRemotelyControlledSampler_updateSampler(t *testing.T) {
 
 			metricsFactory.AssertCounterMetrics(t,
 				mTestutils.ExpectedMetric{
-					Name: "jaeger_tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1,
+					Name: "jaeger.tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1,
 				},
 			)
 
@@ -485,7 +485,7 @@ func TestSamplerQueryError(t *testing.T) {
 	assert.Equal(t, initSampler, sampler.sampler, "Sampler should not have been updated due to query error")
 
 	metricsFactory.AssertCounterMetrics(t,
-		mTestutils.ExpectedMetric{Name: "jaeger_tracer.sampler_queries", Tags: map[string]string{"result": "err"}, Value: 1},
+		mTestutils.ExpectedMetric{Name: "jaeger.tracer.sampler_queries", Tags: map[string]string{"result": "err"}, Value: 1},
 	)
 }
 
@@ -538,8 +538,8 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 	remoteSampler.updateSampler()
 
 	metricsFactory.AssertCounterMetrics(t,
-		mTestutils.ExpectedMetric{Name: "jaeger_tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 3},
-		mTestutils.ExpectedMetric{Name: "jaeger_tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 3},
+		mTestutils.ExpectedMetric{Name: "jaeger.tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 3},
+		mTestutils.ExpectedMetric{Name: "jaeger.tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 3},
 	)
 }
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -91,9 +91,9 @@ func (s *tracerSuite) TestBeginRootSpan() {
 	s.NotNil(ss.duration)
 
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger_tracer.finished_spans", Value: 1},
-		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1},
-		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "jaeger.tracer.finished_spans", Value: 1},
+		{Name: "jaeger.tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1},
+		{Name: "jaeger.tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
 	}...)
 }
 
@@ -114,9 +114,9 @@ func (s *tracerSuite) TestStartChildSpan() {
 	s.NotNil(sp2.(*Span).duration)
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
-		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
-		{Name: "jaeger_tracer.finished_spans", Value: 2},
+		{Name: "jaeger.tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
+		{Name: "jaeger.tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "jaeger.tracer.finished_spans", Value: 2},
 	}...)
 }
 
@@ -145,9 +145,9 @@ func (s *tracerSuite) TestStartSpanWithMultipleReferences() {
 	sp2.Finish()
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 4},
-		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 3},
-		{Name: "jaeger_tracer.finished_spans", Value: 4},
+		{Name: "jaeger.tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 4},
+		{Name: "jaeger.tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 3},
+		{Name: "jaeger.tracer.finished_spans", Value: 4},
 	}...)
 	assert.Len(s.T(), sp4.(*Span).references, 3)
 }
@@ -165,9 +165,9 @@ func (s *tracerSuite) TestStartSpanWithOnlyFollowFromReference() {
 	s.NotNil(sp2.(*Span).duration)
 	sp1.Finish()
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-		{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
-		{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
-		{Name: "jaeger_tracer.finished_spans", Value: 2},
+		{Name: "jaeger.tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 2},
+		{Name: "jaeger.tracer.traces", Tags: map[string]string{"sampled": "y", "state": "started"}, Value: 1},
+		{Name: "jaeger.tracer.finished_spans", Value: 2},
 	}...)
 	assert.Len(s.T(), sp2.(*Span).references, 1)
 }
@@ -195,10 +195,10 @@ func (s *tracerSuite) TestTraceStartedOrJoinedMetrics() {
 		s.Equal(test.sampled, sp2.Context().(SpanContext).IsSampled())
 
 		s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
-			{Name: "jaeger_tracer.started_spans", Tags: map[string]string{"sampled": test.label}, Value: 3},
-			{Name: "jaeger_tracer.finished_spans", Value: 3},
-			{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": test.label, "state": "started"}, Value: 1},
-			{Name: "jaeger_tracer.traces", Tags: map[string]string{"sampled": test.label, "state": "joined"}, Value: 1},
+			{Name: "jaeger.tracer.started_spans", Tags: map[string]string{"sampled": test.label}, Value: 3},
+			{Name: "jaeger.tracer.finished_spans", Value: 3},
+			{Name: "jaeger.tracer.traces", Tags: map[string]string{"sampled": test.label, "state": "started"}, Value: 1},
+			{Name: "jaeger.tracer.traces", Tags: map[string]string{"sampled": test.label, "state": "joined"}, Value: 1},
 		}...)
 	}
 }


### PR DESCRIPTION
…ric backend

Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
PR #346 changed the default namespace for tracer metrics to be `jaeger_tracer` - however this is inconsistent with the separator used with other components (e.g. for expvar).

## Short description of the changes
This PR separates the two parts of the namespace, i.e. `jaeger` and `tracer`, so the appropriate metrics backend separator is used.
