### PR TITLE
Update zipkin propagation logic to support 128bit traceIDs

### DIFF
--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -42,8 +42,7 @@ func (p Propagator) Inject(
 		return opentracing.ErrInvalidCarrier
 	}
 
-	// TODO this needs to change to support 128bit IDs
-	textMapWriter.Set("x-b3-traceid", strconv.FormatUint(sc.TraceID().Low, 16))
+	textMapWriter.Set("x-b3-traceid", sc.TraceID().String())
 	if sc.ParentID() != 0 {
 		textMapWriter.Set("x-b3-parentspanid", strconv.FormatUint(uint64(sc.ParentID()), 16))
 	}
@@ -62,7 +61,7 @@ func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, er
 	if !ok {
 		return jaeger.SpanContext{}, opentracing.ErrInvalidCarrier
 	}
-	var traceID uint64
+	var traceID jaeger.TraceID
 	var spanID uint64
 	var parentID uint64
 	sampled := false
@@ -70,7 +69,7 @@ func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, er
 		key := strings.ToLower(rawKey) // TODO not necessary for plain TextMap
 		var err error
 		if key == "x-b3-traceid" {
-			traceID, err = strconv.ParseUint(value, 16, 64)
+			traceID, err = jaeger.TraceIDFromString(value)
 		} else if key == "x-b3-parentspanid" {
 			parentID, err = strconv.ParseUint(value, 16, 64)
 		} else if key == "x-b3-spanid" {
@@ -84,11 +83,11 @@ func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, er
 	if err != nil {
 		return jaeger.SpanContext{}, err
 	}
-	if traceID == 0 {
+	if !traceID.IsValid() {
 		return jaeger.SpanContext{}, opentracing.ErrSpanContextNotFound
 	}
 	return jaeger.NewSpanContext(
-		jaeger.TraceID{Low: traceID},
+		traceID,
 		jaeger.SpanID(spanID),
 		jaeger.SpanID(parentID),
 		sampled, nil), nil

--- a/zipkin/propagation_test.go
+++ b/zipkin/propagation_test.go
@@ -15,6 +15,7 @@
 package zipkin
 
 import (
+	"strconv"
 	"testing"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -62,6 +63,16 @@ var (
 		"x-b3-spanid":       "afsdfsdf",
 		"x-b3-parentspanid": "hiagggdf",
 		"x-b3-sampled":      "sdfgsdfg",
+	}
+	sampled128bitTraceID = opentracing.TextMapCarrier{
+		"x-b3-traceid": "463ac35c9f6413ad48485a3953bb6124",
+		"x-b3-spanid":  "2",
+		"x-b3-sampled": "1",
+	}
+	invalidTraceID = opentracing.TextMapCarrier{
+		"x-b3-traceid": "00000000000000000000000000000000",
+		"x-b3-spanid":  "2",
+		"x-b3-sampled": "1",
 	}
 )
 
@@ -133,4 +144,22 @@ func TestInjectorNonRootNonSampled(t *testing.T) {
 	err := propagator.Inject(nonRootNonSampled, hdr)
 	assert.Nil(t, err)
 	assert.EqualValues(t, nonRootNonSampledHeader, hdr)
+}
+
+func Test128bitTraceID(t *testing.T) {
+	spanCtx, err := propagator.Extract(sampled128bitTraceID)
+	assert.Nil(t, err)
+
+	high, _ := strconv.ParseUint("463ac35c9f6413ad", 16, 64)
+	low, _ := strconv.ParseUint("48485a3953bb6124", 16, 64)
+	assert.EqualValues(t, spanCtx.TraceID(), jaeger.TraceID{High: high, Low: low})
+
+	hdr := opentracing.TextMapCarrier{}
+	propagator.Inject(spanCtx, hdr)
+	assert.EqualValues(t, hdr["x-b3-traceid"], sampled128bitTraceID["x-b3-traceid"])
+}
+
+func TestInvalid128bitTraceID(t *testing.T) {
+	_, err := propagator.Extract(invalidTraceID)
+	assert.EqualError(t, err, opentracing.ErrSpanContextNotFound.Error())
 }

--- a/zipkin/propagation_test.go
+++ b/zipkin/propagation_test.go
@@ -152,11 +152,12 @@ func Test128bitTraceID(t *testing.T) {
 
 	high, _ := strconv.ParseUint("463ac35c9f6413ad", 16, 64)
 	low, _ := strconv.ParseUint("48485a3953bb6124", 16, 64)
-	assert.EqualValues(t, spanCtx.TraceID(), jaeger.TraceID{High: high, Low: low})
+	assert.EqualValues(t, jaeger.TraceID{High: high, Low: low}, spanCtx.TraceID())
 
 	hdr := opentracing.TextMapCarrier{}
-	propagator.Inject(spanCtx, hdr)
-	assert.EqualValues(t, hdr["x-b3-traceid"], sampled128bitTraceID["x-b3-traceid"])
+	err = propagator.Inject(spanCtx, hdr)
+	assert.Nil(t, err)
+	assert.EqualValues(t, sampled128bitTraceID["x-b3-traceid"], hdr["x-b3-traceid"])
 }
 
 func TestInvalid128bitTraceID(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Zipkin propagation logic does not support 128bit trace IDs

## Short description of the changes
- Use existing TraceID support for 128bit parsing/serialization instead of custom logic in the propagation.go file
