### PR TITLE
Move the AgentClientUDP definition out of the utils package to improve SOC

### DIFF
--- a/testutils/mock_agent.go
+++ b/testutils/mock_agent.go
@@ -23,13 +23,14 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/uber/jaeger-client-go/udp"
+
 	"github.com/uber/jaeger-client-go/thrift"
 
 	"github.com/uber/jaeger-client-go/thrift-gen/agent"
 	"github.com/uber/jaeger-client-go/thrift-gen/jaeger"
 	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
 	"github.com/uber/jaeger-client-go/thrift-gen/zipkincore"
-	"github.com/uber/jaeger-client-go/utils"
 )
 
 // StartMockAgent runs a mock representation of jaeger-agent.
@@ -83,7 +84,7 @@ func (s *MockAgent) SpanServerAddr() string {
 
 // SpanServerClient returns a UDP client that can be used to send spans to the MockAgent
 func (s *MockAgent) SpanServerClient() (agent.Agent, error) {
-	return utils.NewAgentClientUDP(s.SpanServerAddr(), 0)
+	return udp.NewAgentClientUDP(s.SpanServerAddr(), 0)
 }
 
 // SamplingServerAddr returns the host:port of HTTP server exposing sampling strategy endpoint
@@ -94,8 +95,8 @@ func (s *MockAgent) SamplingServerAddr() string {
 func (s *MockAgent) serve(started *sync.WaitGroup) {
 	handler := agent.NewAgentProcessor(s)
 	protocolFact := thrift.NewTCompactProtocolFactory()
-	buf := make([]byte, utils.UDPPacketMaxLength, utils.UDPPacketMaxLength)
-	trans := thrift.NewTMemoryBufferLen(utils.UDPPacketMaxLength)
+	buf := make([]byte, udp.UDPPacketMaxLength)
+	trans := thrift.NewTMemoryBufferLen(udp.UDPPacketMaxLength)
 
 	atomic.StoreUint32(&s.serving, 1)
 	started.Done()

--- a/transport_udp.go
+++ b/transport_udp.go
@@ -18,10 +18,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/uber/jaeger-client-go/udp"
+
 	"github.com/uber/jaeger-client-go/thrift"
 
 	j "github.com/uber/jaeger-client-go/thrift-gen/jaeger"
-	"github.com/uber/jaeger-client-go/utils"
 )
 
 // Empirically obtained constant for how many bytes in the message are used for envelope.
@@ -35,7 +36,7 @@ const emitBatchOverhead = 30
 var errSpanTooLarge = errors.New("Span is too large")
 
 type udpSender struct {
-	client          *utils.AgentClientUDP
+	client          *udp.AgentClientUDP
 	maxPacketSize   int                   // max size of datagram in bytes
 	maxSpanBytes    int                   // max number of bytes to record spans (excluding envelope) in the datagram
 	byteBufferSize  int                   // current number of span bytes accumulated in the buffer
@@ -52,7 +53,7 @@ func NewUDPTransport(hostPort string, maxPacketSize int) (Transport, error) {
 		hostPort = fmt.Sprintf("%s:%d", DefaultUDPSpanServerHost, DefaultUDPSpanServerPort)
 	}
 	if maxPacketSize == 0 {
-		maxPacketSize = utils.UDPPacketMaxLength
+		maxPacketSize = udp.UDPPacketMaxLength
 	}
 
 	protocolFactory := thrift.NewTCompactProtocolFactory()
@@ -61,7 +62,7 @@ func NewUDPTransport(hostPort string, maxPacketSize int) (Transport, error) {
 	thriftBuffer := thrift.NewTMemoryBufferLen(maxPacketSize)
 	thriftProtocol := protocolFactory.GetProtocol(thriftBuffer)
 
-	client, err := utils.NewAgentClientUDP(hostPort, maxPacketSize)
+	client, err := udp.NewAgentClientUDP(hostPort, maxPacketSize)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "net"
+
+// GetUDPConnection returns an instance of net.UDPConn from the `hostPort` and
+// sets its write buffer to the value specified in `maxPacketSize.`
+func GetUDPConnection(hostPort string, maxPacketSize int) (*net.UDPConn, error) {
+	destAddr, err := net.ResolveUDPAddr("udp", hostPort)
+	if err != nil {
+		return nil, err
+	}
+	connUDP, err := net.DialUDP(destAddr.Network(), nil, destAddr)
+	if err != nil {
+		return nil, err
+	}
+	if err := connUDP.SetWriteBuffer(maxPacketSize); err != nil {
+		return nil, err
+	}
+	return connUDP, nil
+}


### PR DESCRIPTION
Reason for this PR:

i) By convention, utils packages are meant to be as generic and as reusable as possible. By adding the thrift package references, it becomes less reusable in the long run. This should maintain the separation of concerns principle.

ii) It is better to have the agentClientUDP in a dedicated package `udp`.