### PR TITLE
Fix the JAEGER_TAGS variable default value which is not optional as stated in the docs

### DIFF
--- a/config/config_env.go
+++ b/config/config_env.go
@@ -197,6 +197,7 @@ func reporterConfigFromEnv() (*ReporterConfig, error) {
 // - comma separated list of key=value
 // - value can be specified using the notation ${envVar:defaultValue}, where `envVar`
 // is an environment variable and `defaultValue` is the value to use in case the env var is not set
+// and `defaultValue` is optional
 func parseTags(sTags string) []opentracing.Tag {
 	pairs := strings.Split(sTags, ",")
 	tags := make([]opentracing.Tag, 0)
@@ -206,10 +207,10 @@ func parseTags(sTags string) []opentracing.Tag {
 
 		if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") {
 			ed := strings.SplitN(v[2:len(v)-1], ":", 2)
-			e, d := ed[0], ed[1]
+			e := ed[0]
 			v = os.Getenv(e)
-			if v == "" && d != "" {
-				v = d
+			if v == "" && len(ed) == 2 {
+				v = ed[1]
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: coffin5257 <coffin5257@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- By the README docs `The value can also refer to an environment variable using the format ${envVarName:default}, where the :default is optional, and identifies a value to be used if the environment variable cannot be found` , but `JAEGER_TAGS` without default value like `${key}` will failed in `parseTags`. 

## Short description of the changes
- `config/config_env.go`: check splited `${envVarName:default}` length before using the default
