### PR TITLE
Add support for 128bit trace ids to zipkin thrift spans.

### DIFF
--- a/thrift-gen/jaeger/ttypes.go
+++ b/thrift-gen/jaeger/ttypes.go
@@ -866,6 +866,7 @@ func (p *SpanRef) String() string {
 //  - Duration
 //  - Tags
 //  - Logs
+//  - Incomplete
 type Span struct {
 	TraceIdLow    int64      `thrift:"traceIdLow,1,required" json:"traceIdLow"`
 	TraceIdHigh   int64      `thrift:"traceIdHigh,2,required" json:"traceIdHigh"`
@@ -878,6 +879,7 @@ type Span struct {
 	Duration      int64      `thrift:"duration,9,required" json:"duration"`
 	Tags          []*Tag     `thrift:"tags,10" json:"tags,omitempty"`
 	Logs          []*Log     `thrift:"logs,11" json:"logs,omitempty"`
+	Incomplete    *bool      `thrift:"incomplete,12" json:"incomplete,omitempty"`
 }
 
 func NewSpan() *Span {
@@ -933,6 +935,15 @@ var Span_Logs_DEFAULT []*Log
 func (p *Span) GetLogs() []*Log {
 	return p.Logs
 }
+
+var Span_Incomplete_DEFAULT bool
+
+func (p *Span) GetIncomplete() bool {
+	if !p.IsSetIncomplete() {
+		return Span_Incomplete_DEFAULT
+	}
+	return *p.Incomplete
+}
 func (p *Span) IsSetReferences() bool {
 	return p.References != nil
 }
@@ -943,6 +954,10 @@ func (p *Span) IsSetTags() bool {
 
 func (p *Span) IsSetLogs() bool {
 	return p.Logs != nil
+}
+
+func (p *Span) IsSetIncomplete() bool {
+	return p.Incomplete != nil
 }
 
 func (p *Span) Read(iprot thrift.TProtocol) error {
@@ -1018,6 +1033,10 @@ func (p *Span) Read(iprot thrift.TProtocol) error {
 			}
 		case 11:
 			if err := p.readField11(iprot); err != nil {
+				return err
+			}
+		case 12:
+			if err := p.readField12(iprot); err != nil {
 				return err
 			}
 		default:
@@ -1191,6 +1210,15 @@ func (p *Span) readField11(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *Span) readField12(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 12: ", err)
+	} else {
+		p.Incomplete = &v
+	}
+	return nil
+}
+
 func (p *Span) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("Span"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -1226,6 +1254,9 @@ func (p *Span) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField11(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField12(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -1405,6 +1436,21 @@ func (p *Span) writeField11(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 11:logs: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *Span) writeField12(oprot thrift.TProtocol) (err error) {
+	if p.IsSetIncomplete() {
+		if err := oprot.WriteFieldBegin("incomplete", thrift.BOOL, 12); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 12:incomplete: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.Incomplete)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.incomplete (12) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 12:incomplete: ", p), err)
 		}
 	}
 	return err

--- a/thrift-gen/jaeger/ttypes.go
+++ b/thrift-gen/jaeger/ttypes.go
@@ -866,7 +866,6 @@ func (p *SpanRef) String() string {
 //  - Duration
 //  - Tags
 //  - Logs
-//  - Incomplete
 type Span struct {
 	TraceIdLow    int64      `thrift:"traceIdLow,1,required" json:"traceIdLow"`
 	TraceIdHigh   int64      `thrift:"traceIdHigh,2,required" json:"traceIdHigh"`
@@ -879,7 +878,6 @@ type Span struct {
 	Duration      int64      `thrift:"duration,9,required" json:"duration"`
 	Tags          []*Tag     `thrift:"tags,10" json:"tags,omitempty"`
 	Logs          []*Log     `thrift:"logs,11" json:"logs,omitempty"`
-	Incomplete    *bool      `thrift:"incomplete,12" json:"incomplete,omitempty"`
 }
 
 func NewSpan() *Span {
@@ -935,15 +933,6 @@ var Span_Logs_DEFAULT []*Log
 func (p *Span) GetLogs() []*Log {
 	return p.Logs
 }
-
-var Span_Incomplete_DEFAULT bool
-
-func (p *Span) GetIncomplete() bool {
-	if !p.IsSetIncomplete() {
-		return Span_Incomplete_DEFAULT
-	}
-	return *p.Incomplete
-}
 func (p *Span) IsSetReferences() bool {
 	return p.References != nil
 }
@@ -954,10 +943,6 @@ func (p *Span) IsSetTags() bool {
 
 func (p *Span) IsSetLogs() bool {
 	return p.Logs != nil
-}
-
-func (p *Span) IsSetIncomplete() bool {
-	return p.Incomplete != nil
 }
 
 func (p *Span) Read(iprot thrift.TProtocol) error {
@@ -1033,10 +1018,6 @@ func (p *Span) Read(iprot thrift.TProtocol) error {
 			}
 		case 11:
 			if err := p.readField11(iprot); err != nil {
-				return err
-			}
-		case 12:
-			if err := p.readField12(iprot); err != nil {
 				return err
 			}
 		default:
@@ -1210,15 +1191,6 @@ func (p *Span) readField11(iprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p *Span) readField12(iprot thrift.TProtocol) error {
-	if v, err := iprot.ReadBool(); err != nil {
-		return thrift.PrependError("error reading field 12: ", err)
-	} else {
-		p.Incomplete = &v
-	}
-	return nil
-}
-
 func (p *Span) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("Span"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -1254,9 +1226,6 @@ func (p *Span) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField11(oprot); err != nil {
-		return err
-	}
-	if err := p.writeField12(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -1436,21 +1405,6 @@ func (p *Span) writeField11(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 11:logs: ", p), err)
-		}
-	}
-	return err
-}
-
-func (p *Span) writeField12(oprot thrift.TProtocol) (err error) {
-	if p.IsSetIncomplete() {
-		if err := oprot.WriteFieldBegin("incomplete", thrift.BOOL, 12); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field begin error 12:incomplete: ", p), err)
-		}
-		if err := oprot.WriteBool(bool(*p.Incomplete)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T.incomplete (12) field write error: ", p), err)
-		}
-		if err := oprot.WriteFieldEnd(); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field end error 12:incomplete: ", p), err)
 		}
 	}
 	return err

--- a/thrift-gen/zipkincore/constants.go
+++ b/thrift-gen/zipkincore/constants.go
@@ -18,6 +18,8 @@ const CLIENT_SEND = "cs"
 const CLIENT_RECV = "cr"
 const SERVER_SEND = "ss"
 const SERVER_RECV = "sr"
+const MESSAGE_SEND = "ms"
+const MESSAGE_RECV = "mr"
 const WIRE_SEND = "ws"
 const WIRE_RECV = "wr"
 const CLIENT_SEND_FRAGMENT = "csf"
@@ -27,6 +29,7 @@ const SERVER_RECV_FRAGMENT = "srf"
 const LOCAL_COMPONENT = "lc"
 const CLIENT_ADDR = "ca"
 const SERVER_ADDR = "sa"
+const MESSAGE_ADDR = "ma"
 
 func init() {
 }

--- a/zipkin_thrift_span.go
+++ b/zipkin_thrift_span.go
@@ -48,6 +48,11 @@ func BuildZipkinThrift(s *Span) *z.Span {
 	if parentID != 0 {
 		ptrParentID = &parentID
 	}
+	traceIDHigh := int64(span.context.traceID.High)
+	var ptrTraceIDHigh *int64
+	if traceIDHigh != 0 {
+		ptrTraceIDHigh = &traceIDHigh
+	}
 	timestamp := utils.TimeToMicrosecondsSinceEpochInt64(span.startTime)
 	duration := span.duration.Nanoseconds() / int64(time.Microsecond)
 	endpoint := &z.Endpoint{
@@ -55,6 +60,7 @@ func BuildZipkinThrift(s *Span) *z.Span {
 		Ipv4:        int32(span.tracer.hostIPv4)}
 	thriftSpan := &z.Span{
 		TraceID:           int64(span.context.traceID.Low), // TODO upgrade zipkin thrift and use TraceIdHigh
+		TraceIDHigh:       ptrTraceIDHigh,
 		ID:                int64(span.context.spanID),
 		ParentID:          ptrParentID,
 		Name:              span.operationName,

--- a/zipkin_thrift_span.go
+++ b/zipkin_thrift_span.go
@@ -59,7 +59,7 @@ func BuildZipkinThrift(s *Span) *z.Span {
 		ServiceName: span.tracer.serviceName,
 		Ipv4:        int32(span.tracer.hostIPv4)}
 	thriftSpan := &z.Span{
-		TraceID:           int64(span.context.traceID.Low), // TODO upgrade zipkin thrift and use TraceIdHigh
+		TraceID:           int64(span.context.traceID.Low),
 		TraceIDHigh:       ptrTraceIDHigh,
 		ID:                int64(span.context.spanID),
 		ParentID:          ptrParentID,

--- a/zipkin_thrift_span_test.go
+++ b/zipkin_thrift_span_test.go
@@ -34,7 +34,9 @@ import (
 func TestThriftFirstInProcessSpan(t *testing.T) {
 	tracer, closer := NewTracer("DOOP",
 		NewConstSampler(true),
-		NewNullReporter())
+		NewNullReporter(),
+		TracerOptions.Gen128Bit(true),
+	)
 	defer closer.Close()
 
 	sp1 := tracer.StartSpan("s1").(*Span)
@@ -62,6 +64,7 @@ func TestThriftFirstInProcessSpan(t *testing.T) {
 		hostname := findBinaryAnnotation(thriftSpan, TracerHostnameTagKey)
 		check(t, version)
 		check(t, hostname)
+		assert.NotNil(t, thriftSpan.TraceIDHigh)
 	}
 }
 

--- a/zipkin_thrift_span_test.go
+++ b/zipkin_thrift_span_test.go
@@ -34,9 +34,7 @@ import (
 func TestThriftFirstInProcessSpan(t *testing.T) {
 	tracer, closer := NewTracer("DOOP",
 		NewConstSampler(true),
-		NewNullReporter(),
-		TracerOptions.Gen128Bit(true),
-	)
+		NewNullReporter())
 	defer closer.Close()
 
 	sp1 := tracer.StartSpan("s1").(*Span)
@@ -64,8 +62,39 @@ func TestThriftFirstInProcessSpan(t *testing.T) {
 		hostname := findBinaryAnnotation(thriftSpan, TracerHostnameTagKey)
 		check(t, version)
 		check(t, hostname)
-		assert.NotNil(t, thriftSpan.TraceIDHigh)
 	}
+}
+
+func Test128bitTraceIDs(t *testing.T) {
+	tracer128, closer128 := NewTracer("OneTwentyEight",
+		NewConstSampler(true),
+		NewNullReporter(),
+		TracerOptions.Gen128Bit(true),
+	)
+	defer closer128.Close()
+
+	tracer64, closer64 := NewTracer("SixtyFour",
+		NewConstSampler(true),
+		NewNullReporter(),
+		TracerOptions.Gen128Bit(false),
+	)
+	defer closer64.Close()
+
+	sp1 := tracer128.StartSpan("s1").(*Span)
+	sp2 := tracer128.StartSpan("sp2", opentracing.ChildOf(sp1.Context())).(*Span)
+	sp2.Finish()
+	sp1.Finish()
+
+	thriftSpan1 := BuildZipkinThrift(sp1)
+	assert.NotNil(t, thriftSpan1.TraceIDHigh)
+
+	thriftSpan2 := BuildZipkinThrift(sp2)
+	assert.NotNil(t, thriftSpan2.TraceIDHigh)
+
+	sp3 := tracer64.StartSpan("s3").(*Span)
+	sp3.Finish()
+	thriftSpan3 := BuildZipkinThrift(sp3)
+	assert.Nil(t, thriftSpan3.TraceIDHigh)
 }
 
 func TestThriftForceSampled(t *testing.T) {


### PR DESCRIPTION
Includes:
- Updating IDL to `3471ffb`
- Running make thrift
- Add TraceIDHigh to zipkin_thrift_span

Note: I manually verified this by running a binary with these changes compiled in, as illustrated in https://github.com/istio/istio/issues/11954#issuecomment-466594923.

Signed-off-by: Douglas Reid <dougreid@google.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Zipkin trace export drops the high order 64bits from trace ids

## Short description of the changes
- updated the idl submodule, ran the thrift-gen, added a few lines to include the new field.
