### PR TITLE
 Fix the span allocation in the pool

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -93,13 +93,14 @@ func NewInMemoryReporter() *InMemoryReporter {
 // Report implements Report() method of Reporter by storing the span in the buffer.
 func (r *InMemoryReporter) Report(span *Span) {
 	r.lock.Lock()
-	r.spans = append(r.spans, span)
+	// Need to retain the span otherwise it will be released
+	r.spans = append(r.spans, span.Retain())
 	r.lock.Unlock()
 }
 
-// Close implements Close() method of Reporter by doing nothing.
+// Close implements Close() method of Reporter
 func (r *InMemoryReporter) Close() {
-	// no-op
+	r.Reset()
 }
 
 // SpansSubmitted returns the number of spans accumulated in the buffer.
@@ -122,7 +123,14 @@ func (r *InMemoryReporter) GetSpans() []opentracing.Span {
 func (r *InMemoryReporter) Reset() {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	r.spans = nil
+
+	if len(r.spans) > 0 {
+		// Before reset the collection need to release Span memory
+		for _, span := range r.spans {
+			span.(*Span).Release()
+		}
+		r.spans = r.spans[:0]
+	}
 }
 
 // ------------------------------
@@ -218,7 +226,8 @@ func NewRemoteReporter(sender Transport, opts ...ReporterOption) Reporter {
 // because some of them may still be successfully added to the queue.
 func (r *remoteReporter) Report(span *Span) {
 	select {
-	case r.queue <- reporterQueueItem{itemType: reporterQueueItemSpan, span: span}:
+	// Need to retain the span otherwise it will be released
+	case r.queue <- reporterQueueItem{itemType: reporterQueueItemSpan, span: span.Retain()}:
 		atomic.AddInt64(&r.queueLength, 1)
 	default:
 		r.metrics.ReporterDropped.Inc(1)
@@ -278,6 +287,7 @@ func (r *remoteReporter) processQueue() {
 					// to reduce the number of gauge stats, we only emit queue length on flush
 					r.metrics.ReporterQueueLength.Update(atomic.LoadInt64(&r.queueLength))
 				}
+				span.Release()
 			case reporterQueueItemClose:
 				timer.Stop()
 				flush()

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -143,6 +143,17 @@ func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
 	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\nERROR: error when flushing the buffer: flush error\n")
 }
 
+func TestRemoteReporterAppendWithPollAllocator(t *testing.T) {
+	s := makeReporterSuiteWithSender(t, &fakeSender{bufferSize: 10}, ReporterOptions.BufferFlushInterval(time.Millisecond*10))
+	TracerOptions.PoolSpans(true)(s.tracer.(*Tracer))
+	for i := 0; i < 1000; i++ {
+		s.tracer.StartSpan("sp").Finish()
+	}
+	time.Sleep(time.Second)
+	s.sender.assertFlushedSpans(t, 1000)
+	s.close() // causes explicit flush that also fails with the same error
+}
+
 func TestRemoteReporterDroppedSpans(t *testing.T) {
 	s := makeReporterSuite(t, ReporterOptions.QueueSize(1))
 	defer s.close()
@@ -301,6 +312,10 @@ func (s *fakeSender) Append(span *Span) (int, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	// Validation of span
+	if span.tracer == nil {
+		return 0, s.appendErr
+	}
 	s.spans = append(s.spans, span)
 	if n := len(s.spans); n == s.bufferSize {
 		return s.flushNoLock()

--- a/span_allocator.go
+++ b/span_allocator.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import "sync"
+
+// SpanAllocator abstraction of managign span allocations
+type SpanAllocator interface {
+	Get() *Span
+	Put(*Span)
+	IsPool() bool
+}
+
+type spanSyncPool struct {
+	spanPool sync.Pool
+}
+
+func newSpanSyncPool() SpanAllocator {
+	return &spanSyncPool{
+		spanPool: sync.Pool{New: func() interface{} {
+			return &Span{}
+		}},
+	}
+}
+
+func (pool *spanSyncPool) Get() *Span {
+	return pool.spanPool.Get().(*Span)
+}
+
+func (pool *spanSyncPool) Put(span *Span) {
+	span.reset()
+	pool.spanPool.Put(span)
+}
+
+func (pool *spanSyncPool) IsPool() bool {
+	return true
+}
+
+type spanSimpleAllocator struct{}
+
+func (pool spanSimpleAllocator) Get() *Span {
+	return &Span{}
+}
+
+func (pool spanSimpleAllocator) Put(span *Span) {
+	span.reset()
+}
+
+func (pool spanSimpleAllocator) IsPool() bool {
+	return false
+}

--- a/span_allocator_test.go
+++ b/span_allocator_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import "testing"
+
+func BenchmarkSpanAllocator(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	b.Run("SyncPool", func(b *testing.B) {
+		benchSpanAllocator(newSpanSyncPool(), b)
+	})
+
+	b.Run("Simple", func(b *testing.B) {
+		benchSpanAllocator(spanSimpleAllocator{}, b)
+	})
+}
+
+func benchSpanAllocator(allocator SpanAllocator, b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		queue := make(chan *Span, 1000)
+		cancel := make(chan bool, 1)
+		go func() {
+			for span := range queue {
+				allocator.Put(span)
+			}
+			cancel <- true
+		}()
+		for pb.Next() {
+			queue <- allocator.Get()
+		}
+		close(queue)
+		<-cancel
+	})
+}

--- a/span_test.go
+++ b/span_test.go
@@ -88,7 +88,7 @@ func TestSpanOperationName(t *testing.T) {
 
 	sp1 := tracer.StartSpan("s1").(*Span)
 	sp1.SetOperationName("s2")
-	sp1.Finish()
+	defer sp1.Finish()
 
 	assert.Equal(t, "s2", sp1.OperationName())
 }

--- a/tracer.go
+++ b/tracer.go
@@ -47,15 +47,14 @@ type Tracer struct {
 	randomNumber func() uint64
 
 	options struct {
-		poolSpans            bool
 		gen128Bit            bool // whether to generate 128bit trace IDs
 		zipkinSharedRPCSpan  bool
 		highTraceIDGenerator func() uint64 // custom high trace ID generator
 		maxTagValueLength    int
 		// more options to come
 	}
-	// pool for Span objects
-	spanPool sync.Pool
+	// allocator of Span objects
+	spanAllocator SpanAllocator
 
 	injectors  map[interface{}]Injector
 	extractors map[interface{}]Extractor
@@ -81,15 +80,13 @@ func NewTracer(
 	options ...TracerOption,
 ) (opentracing.Tracer, io.Closer) {
 	t := &Tracer{
-		serviceName: serviceName,
-		sampler:     sampler,
-		reporter:    reporter,
-		injectors:   make(map[interface{}]Injector),
-		extractors:  make(map[interface{}]Extractor),
-		metrics:     *NewNullMetrics(),
-		spanPool: sync.Pool{New: func() interface{} {
-			return &Span{}
-		}},
+		serviceName:   serviceName,
+		sampler:       sampler,
+		reporter:      reporter,
+		injectors:     make(map[interface{}]Injector),
+		extractors:    make(map[interface{}]Extractor),
+		metrics:       *NewNullMetrics(),
+		spanAllocator: spanSimpleAllocator{},
 	}
 
 	for _, option := range options {
@@ -349,15 +346,7 @@ func (t *Tracer) Tags() []opentracing.Tag {
 // newSpan returns an instance of a clean Span object.
 // If options.PoolSpans is true, the spans are retrieved from an object pool.
 func (t *Tracer) newSpan() *Span {
-	if !t.options.poolSpans {
-		return &Span{}
-	}
-	sp := t.spanPool.Get().(*Span)
-	sp.context = emptyContext
-	sp.tracer = nil
-	sp.tags = nil
-	sp.logs = nil
-	return sp
+	return t.spanAllocator.Get()
 }
 
 func (t *Tracer) startSpanInternal(
@@ -412,12 +401,15 @@ func (t *Tracer) startSpanInternal(
 
 func (t *Tracer) reportSpan(sp *Span) {
 	t.metrics.SpansFinished.Inc(1)
+
+	// Note: if the reporter is processing Span asynchronously need to Retain() it
+	// otherwise, in the racing condition will be rewritten span data before it will be sent
+	// * To remove object use method span.Release()
 	if sp.context.IsSampled() {
 		t.reporter.Report(sp)
 	}
-	if t.options.poolSpans {
-		t.spanPool.Put(sp)
-	}
+
+	sp.Release()
 }
 
 // randomID generates a random trace/span ID, using tracer.random() generator.

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -81,7 +81,11 @@ func (tracerOptions) RandomNumber(randomNumber func() uint64) TracerOption {
 // that can access parent spans after those spans have been finished.
 func (tracerOptions) PoolSpans(poolSpans bool) TracerOption {
 	return func(tracer *Tracer) {
-		tracer.options.poolSpans = poolSpans
+		if poolSpans {
+			tracer.spanAllocator = newSpanSyncPool()
+		} else {
+			tracer.spanAllocator = spanSimpleAllocator{}
+		}
 	}
 }
 

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -45,8 +45,9 @@ func TestHTTPTransport(t *testing.T) {
 	)
 	defer closer.Close()
 
-	span := tracer.StartSpan("root")
-	span.Finish()
+	span := tracer.StartSpan("root").(*jaeger.Span)
+	span.Retain().Finish()
+	defer span.Release()
 
 	// Need to yield to the select loop to accept the send request, and then
 	// yield again to the send operation to write to the socket. I think the

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -60,8 +60,9 @@ func TestHttpTransport(t *testing.T) {
 		jaeger.NewRemoteReporter(sender),
 	)
 
-	span := tracer.StartSpan("root")
-	span.Finish()
+	span := tracer.StartSpan("root").(*jaeger.Span)
+	span.Retain().Finish()
+	defer span.Release()
 
 	closer.Close()
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Allocation in the pool didn't work properly because of tracer tried to reuse the span object before processing finishing, what spawned errors and data overwriting before spans were sent.

```go
func TestRemoteReporterAppendWithPollAllocator(t *testing.T) {
	s := makeReporterSuiteWithSender(t, &fakeSender{bufferSize: 10}, ReporterOptions.BufferFlushInterval(time.Millisecond*10))
	TracerOptions.PoolSpans(true)(s.tracer.(*Tracer))
	for i := 0; i < 1000; i++ {
		s.tracer.StartSpan("sp").Finish()
	}
	time.Sleep(time.Second)
	s.sender.assertFlushedSpans(t, 1000)
	s.close() // causes explicit flush that also fails with the same error
}
```

```
go test -timeout 30s github.com/uber/jaeger-client-go -run ^(TestRemoteReporterAppendWithPollAllocator)$ -v -race
=== RUN   TestRemoteReporterAppendWithPollAllocator
==================
WARNING: DATA RACE
Write at 0x00c4202223d8 by goroutine 18:
  github.com/uber/jaeger-client-go.(*Tracer).newSpan()
      github.com/uber/jaeger-client-go/tracer.go:357 +0xff
  github.com/uber/jaeger-client-go.(*Tracer).startSpanWithOptions()
      github.com/uber/jaeger-client-go/tracer.go:289 +0xbdd
  github.com/uber/jaeger-client-go.(*Tracer).StartSpan()
      github.com/uber/jaeger-client-go/tracer.go:200 +0x17d
  github.com/uber/jaeger-client-go.TestRemoteReporterAppendWithPollAllocator()
      github.com/uber/jaeger-client-go/reporter_test.go:162 +0x1fc
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Previous read at 0x00c4202223d8 by goroutine 19:
  github.com/uber/jaeger-client-go.(*fakeSender).Append()
      github.com/uber/jaeger-client-go/reporter_test.go:328 +0xb7
  github.com/uber/jaeger-client-go.(*remoteReporter).processQueue()
      github.com/uber/jaeger-client-go/reporter.go:273 +0x2b8

Goroutine 18 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:824 +0x564
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1063 +0xa4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1061 +0x4e1
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:978 +0x2cd
  main.main()
      _testmain.go:212 +0x22a

Goroutine 19 (running) created at:
  github.com/uber/jaeger-client-go.NewRemoteReporter()
      github.com/uber/jaeger-client-go/reporter.go:209 +0x2ec
  github.com/uber/jaeger-client-go.makeReporterSuiteWithSender()
      github.com/uber/jaeger-client-go/reporter_test.go:65 +0x4f3
  github.com/uber/jaeger-client-go.TestRemoteReporterAppendWithPollAllocator()
      github.com/uber/jaeger-client-go/reporter_test.go:159 +0x154
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
--- FAIL: TestRemoteReporterAppendWithPollAllocator (2.35s)
	github.com/uber/jaeger-client-go/assertions.go:256:
			Error Trace:	reporter_test.go:386
			            				reporter_test.go:165
			Error:      	"[61bdfe3abf262a6a:61bdfe3abf262a6a:0:1 ...
			Test:       	TestRemoteReporterAppendWithPollAllocator
	github.com/uber/jaeger-client-go/testing.go:730: race detected during execution of test
```

## Short description of the changes

 * Was added features of controlling of the lifecycle of the span object with ```.Retain()``` and ```.Release()``` methods.
 * Was rewritten the system of allocation of the Span objects via the object factories. See *span_allocator.go*
 * Fixed the module *reporter.go* ```remoteReporter``` what became the reason for racing in the spans allocations.