### PR TITLE
Expose span data to custom reporters [fixes #394]

### DIFF
--- a/span.go
+++ b/span.go
@@ -98,21 +98,29 @@ func (s *Span) SetTag(key string, value interface{}) opentracing.Span {
 
 // SpanContext returns span context
 func (s *Span) SpanContext() SpanContext {
+	s.Lock()
+	defer s.Unlock()
 	return s.context
 }
 
 // StartTime returns span start time
 func (s *Span) StartTime() time.Time {
+	s.Lock()
+	defer s.Unlock()
 	return s.startTime
 }
 
 // Duration returns span duration
 func (s *Span) Duration() time.Duration {
+	s.Lock()
+	defer s.Unlock()
 	return s.duration
 }
 
 // Tags returns tags for span
 func (s *Span) Tags() opentracing.Tags {
+	s.Lock()
+	defer s.Unlock()
 	var result = make(opentracing.Tags)
 	for _, tag := range s.tags {
 		result[tag.key] = tag.value

--- a/span.go
+++ b/span.go
@@ -96,6 +96,30 @@ func (s *Span) SetTag(key string, value interface{}) opentracing.Span {
 	return s
 }
 
+// SpanContext returns span context
+func (s *Span) SpanContext() SpanContext {
+	return s.context
+}
+
+// StartTime returns span start time
+func (s *Span) StartTime() time.Time {
+	return s.startTime
+}
+
+// Duration returns span duration
+func (s *Span) Duration() time.Duration {
+	return s.duration
+}
+
+// Tags returns tags for span
+func (s *Span) Tags() opentracing.Tags {
+	var result = make(opentracing.Tags)
+	for _, tag := range s.tags {
+		result[tag.key] = tag.value
+	}
+	return result
+}
+
 func (s *Span) setTagNoLocking(key string, value interface{}) {
 	s.tags = append(s.tags, Tag{key: key, value: value})
 }

--- a/span_test.go
+++ b/span_test.go
@@ -87,7 +87,7 @@ func TestSpanProperties(t *testing.T) {
 
 	assert.Equal(t, tracer, sp1.Tracer())
 	assert.NotNil(t, sp1.Context())
-	assert.Equal(t, sp1.context, sp1.Context())
+	assert.Equal(t, sp1.context, sp1.SpanContext())
 	assert.Equal(t, sp1.startTime, sp1.StartTime())
 	assert.Equal(t, sp1.duration, sp1.Duration())
 	assert.Equal(t, sp1.Tags(), expectedTags)

--- a/span_test.go
+++ b/span_test.go
@@ -79,8 +79,18 @@ func TestSpanProperties(t *testing.T) {
 	defer closer.Close()
 
 	sp1 := tracer.StartSpan("s1").(*Span)
+	sp1.SetTag("foo", "bar")
+	var expectedTags = make(opentracing.Tags)
+	expectedTags["foo"] = "bar"
+	expectedTags["sampler.type"] = "const"
+	expectedTags["sampler.param"] = true
+
 	assert.Equal(t, tracer, sp1.Tracer())
 	assert.NotNil(t, sp1.Context())
+	assert.Equal(t, sp1.context, sp1.Context())
+	assert.Equal(t, sp1.startTime, sp1.StartTime())
+	assert.Equal(t, sp1.duration, sp1.Duration())
+	assert.Equal(t, sp1.Tags(), expectedTags)
 }
 
 func TestSpanOperationName(t *testing.T) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Fixes #394

## Short description of the changes
While Jaeger supports user-supplied reporters span data is not exported to external packages. Custom reporters should have the ability to access span data.
