### PR TITLE
NewTracer suport passing iptag [fixes #401]

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -375,7 +375,6 @@ func (t *Tracer) setTag(key string, value interface{}) {
 		}
 	}
 	t.tags = append(t.tags, Tag{key, value})
-	return
 }
 
 // newSpan returns an instance of a clean Span object.

--- a/tracer.go
+++ b/tracer.go
@@ -145,17 +145,16 @@ func NewTracer(
 	if hostname, err := os.Hostname(); err == nil {
 		t.tags = append(t.tags, Tag{key: TracerHostnameTagKey, value: hostname})
 	}
-	ipval := t.getTag(TracerIPTagKey)
-	if ipStr, ok := ipval.(string); ok {
-		ipv4, err := utils.ParseIPToUint32(ipStr)
+	if ipval, ok := t.getTag(TracerIPTagKey); ok {
+		ipv4, err := utils.ParseIPToUint32(ipval.(string))
 		if err != nil {
 			t.hostIPv4 = 0
-			t.logger.Error("Unable to convert the specific ip to uint32: " + err.Error())
+			t.logger.Error("Unable to convert the externally provided ip to uint32: " + err.Error())
 		} else {
 			t.hostIPv4 = ipv4
 		}
 	} else if ip, err := utils.HostIP(); err == nil {
-		t.setTag(TracerIPTagKey, ip.String())
+		t.tags = append(t.tags, Tag{key: TracerIPTagKey, value: ip.String()})
 		t.hostIPv4 = utils.PackIPAsUint32(ip)
 	} else {
 		t.logger.Error("Unable to determine this host's IP address: " + err.Error())
@@ -357,24 +356,13 @@ func (t *Tracer) Tags() []opentracing.Tag {
 }
 
 // getTag returns the value of specific tag, if not exists, return nil.
-func (t *Tracer) getTag(key string) interface{} {
+func (t *Tracer) getTag(key string) (interface{}, bool) {
 	for _, tag := range t.tags {
 		if tag.key == key {
-			return tag.value
+			return tag.value, true
 		}
 	}
-	return nil
-}
-
-// setTag set the value of specific tag
-func (t *Tracer) setTag(key string, value interface{}) {
-	for i, tag := range t.tags {
-		if tag.key == key {
-			t.tags[i].value = value
-			return
-		}
-	}
-	t.tags = append(t.tags, Tag{key, value})
+	return nil, false
 }
 
 // newSpan returns an instance of a clean Span object.

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -15,6 +15,7 @@
 package jaeger
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -404,6 +405,57 @@ func TestThrottling_DebugHeader(t *testing.T) {
 
 	sp = tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*Span)
 	assert.False(t, sp.context.IsDebug(), "debug should not be allowed by the throttler")
+}
+
+func TestSetGetTag(t *testing.T) {
+	opentracer, tc := NewTracer("x", NewConstSampler(true), NewNullReporter())
+	tracer := opentracer.(*Tracer)
+	defer tc.Close()
+	tags := tracer.Tags()
+	for _, tag := range tags {
+		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
+	}
+	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
+
+	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, "11.22.33.44"))
+	tracer = opentracer.(*Tracer)
+	defer tc.Close()
+	tags = tracer.Tags()
+	for _, tag := range tags {
+		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
+	}
+	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
+
+	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, "an invalid input"))
+	tracer = opentracer.(*Tracer)
+	defer tc.Close()
+	tags = tracer.Tags()
+	for _, tag := range tags {
+		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
+	}
+	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
+
+	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, nil))
+	tracer = opentracer.(*Tracer)
+	defer tc.Close()
+	tags = tracer.Tags()
+	for _, tag := range tags {
+		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
+	}
+	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
+
+	type empty struct {
+	}
+
+	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, new(empty)))
+	tracer = opentracer.(*Tracer)
+	defer tc.Close()
+	tags = tracer.Tags()
+	for _, tag := range tags {
+		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
+	}
+	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
+
 }
 
 type dummyPropagator struct{}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -15,7 +15,6 @@
 package jaeger
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -411,51 +410,29 @@ func TestSetGetTag(t *testing.T) {
 	opentracer, tc := NewTracer("x", NewConstSampler(true), NewNullReporter())
 	tracer := opentracer.(*Tracer)
 	defer tc.Close()
-	tags := tracer.Tags()
-	for _, tag := range tags {
-		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
-	}
-	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
+	value, ok := tracer.getTag(TracerIPTagKey)
+	assert.True(t, ok)
+	_, ok = value.(string)
+	assert.True(t, ok)
+	assert.True(t, tracer.hostIPv4 != 0)
 
-	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, "11.22.33.44"))
+	ipStr := "11.22.33.44"
+	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, ipStr))
 	tracer = opentracer.(*Tracer)
 	defer tc.Close()
-	tags = tracer.Tags()
-	for _, tag := range tags {
-		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
-	}
-	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
+	value, ok = tracer.getTag(TracerIPTagKey)
+	assert.True(t, ok)
+	assert.True(t, value == ipStr)
+	assert.True(t, tracer.hostIPv4 != 0)
 
-	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, "an invalid input"))
+	ipStrInvalid := "an invalid input"
+	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, ipStrInvalid))
 	tracer = opentracer.(*Tracer)
 	defer tc.Close()
-	tags = tracer.Tags()
-	for _, tag := range tags {
-		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
-	}
-	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
-
-	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, nil))
-	tracer = opentracer.(*Tracer)
-	defer tc.Close()
-	tags = tracer.Tags()
-	for _, tag := range tags {
-		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
-	}
-	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
-
-	type empty struct {
-	}
-
-	opentracer, tc = NewTracer("x", NewConstSampler(true), NewNullReporter(), TracerOptions.Tag(TracerIPTagKey, new(empty)))
-	tracer = opentracer.(*Tracer)
-	defer tc.Close()
-	tags = tracer.Tags()
-	for _, tag := range tags {
-		fmt.Println("key : ", tag.Key, " value : ", tag.Value.(string))
-	}
-	fmt.Println("hostIPv4 : ", tracer.hostIPv4)
-
+	value, ok = tracer.getTag(TracerIPTagKey)
+	assert.True(t, ok)
+	assert.True(t, value == ipStrInvalid)
+	assert.True(t, tracer.hostIPv4 == 0)
 }
 
 type dummyPropagator struct{}


### PR DESCRIPTION
old codes did not support passing a iptag to NewTracer because NewTracer
will overwrite the iptag. Now modify the NewTracer method, make it
support passing iptag

two private method of Tracer add : getTag, setTag
And testing function is also added into tracer_test.go, all test of
NewTracer passed.

Signed-off-by: Canliu Wu <kvcsgame@hotmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves #401 

## Short description of the changes
- 
modified the part of setting iptag in NewTracer method so that NewTracer won't overwrite the iptag the user pass in. Two necessary private method added : setTag, getTag
and test codes also added in tracer_test.go : line 340-371
all tests of NewTracer passed
