### PR TITLE
Self Referenced Span

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,7 @@ Usage requires passing in a `SpanContext` and the jaeger `Self` reference type:
 ```
 span := tracer.StartSpan(
     "continued_span",
-    opentracing.SpanReferenceType{
-        Type: jaeger.SelfRef,
-        ReferencedContext: yourSpanContext,
-    },
+    SelfRef(yourSpanContext),
 )
 ...
 defer span.finish()

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ However it is not the default propagation format, see [here](zipkin/README.md#Ne
 Jaeger Tracer supports an additional [reference](https://github.com/opentracing/specification/blob/1.1/specification.md#references-between-spans)
 type call `Self`. This allows a caller to provide an already established `SpanContext`.
 This allows loading and continuing spans/traces from offline (ie log-based) storage. The `Self` reference
-will bypass trace and span id generation.
+bypasses trace and span id generation.
 
 
 Usage requires passing in a `SpanContext` and the jaeger `Self` reference type:

--- a/README.md
+++ b/README.md
@@ -262,7 +262,6 @@ bypasses trace and span id generation.
 
 
 Usage requires passing in a `SpanContext` and the jaeger `Self` reference type:
-
 ```
 span := tracer.StartSpan(
     "continued_span",

--- a/README.md
+++ b/README.md
@@ -253,6 +253,27 @@ by a lot of Zipkin tracers. This means that you can use Jaeger in conjunction wi
 
 However it is not the default propagation format, see [here](zipkin/README.md#NewZipkinB3HTTPHeaderPropagator) how to set it up.
 
+## SelfRef
+
+Jaeger Tracer supports an additional [reference](https://github.com/opentracing/specification/blob/1.1/specification.md#references-between-spans)
+type call `Self`. This allows a caller to provide an already established `SpanContext`.
+This allows loading and continuing spans/traces from offline (ie log-based) storage. The `Self` reference
+will bypass trace and span id generation.
+
+
+Usage requires passing in a `SpanContext` and the jaeger `Self` reference type:
+```
+span := tracer.StartSpan(
+    "continued_span",
+    opentracing.SpanReferenceType{
+        Type: jaeger.SelfRef,
+        ReferencedContext: yourSpanContext,
+    },
+)
+...
+defer span.finish()
+```
+
 ## License
 
 [Apache 2.0 License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ bypasses trace and span id generation.
 
 
 Usage requires passing in a `SpanContext` and the jaeger `Self` reference type:
+
 ```
 span := tracer.StartSpan(
     "continued_span",

--- a/constants.go
+++ b/constants.go
@@ -14,6 +14,8 @@
 
 package jaeger
 
+import "github.com/opentracing/opentracing-go"
+
 const (
 	// JaegerClientVersion is the version of the client library reported as Span tag.
 	JaegerClientVersion = "Go-2.16.1dev"
@@ -85,4 +87,6 @@ const (
 
 	// DefaultMaxTagValueLength is the default max length of byte array or string allowed in the tag value.
 	DefaultMaxTagValueLength = 256
+
+	SelfRef opentracing.SpanReferenceType = 99
 )

--- a/constants.go
+++ b/constants.go
@@ -88,5 +88,7 @@ const (
 	// DefaultMaxTagValueLength is the default max length of byte array or string allowed in the tag value.
 	DefaultMaxTagValueLength = 256
 
+	// SelfRef is a jaeger specific reference type that supports creating a span
+	// with an already defined context.
 	SelfRef opentracing.SpanReferenceType = 99
 )

--- a/constants.go
+++ b/constants.go
@@ -88,7 +88,7 @@ const (
 	// DefaultMaxTagValueLength is the default max length of byte array or string allowed in the tag value.
 	DefaultMaxTagValueLength = 256
 
-	// SelfRef is a jaeger specific reference type that supports creating a span
+	// SelfRefType is a jaeger specific reference type that supports creating a span
 	// with an already defined context.
-	SelfRef opentracing.SpanReferenceType = 99
+	selfRefType opentracing.SpanReferenceType = 99
 )

--- a/span.go
+++ b/span.go
@@ -24,6 +24,8 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 )
 
+const SelfRef opentracing.SpanReferenceType = 99
+
 // Span implements opentracing.Span
 type Span struct {
 	// referenceCounter used to increase the lifetime of

--- a/span.go
+++ b/span.go
@@ -24,8 +24,6 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 )
 
-const SelfRef opentracing.SpanReferenceType = 99
-
 // Span implements opentracing.Span
 type Span struct {
 	// referenceCounter used to increase the lifetime of

--- a/tracer.go
+++ b/tracer.go
@@ -465,6 +465,9 @@ func (t *Tracer) isDebugAllowed(operation string) bool {
 	return t.debugThrottler.IsAllowed(operation)
 }
 
+// SelfRef creates an opentracing compliant SpanReference from a jaeger
+// SpanContext. This is a factory function in order to encapsulate jaeger specific
+// types.
 func SelfRef(ctx SpanContext) opentracing.SpanReference {
 	return opentracing.SpanReference{
 		Type:              selfRefType,

--- a/tracer.go
+++ b/tracer.go
@@ -235,16 +235,18 @@ func (t *Tracer) startSpanWithOptions(
 		if !isValidReference(ctxRef) {
 			continue
 		}
+
+		if ref.Type == selfRefType {
+			isSelfRef = true
+			ctx = ctxRef
+			continue
+		}
+
 		references = append(references, Reference{Type: ref.Type, Context: ctxRef})
 
 		if !hasParent {
 			parent = ctxRef
 			hasParent = ref.Type == opentracing.ChildOfRef
-		}
-
-		if ref.Type == SelfRef {
-			isSelfRef = true
-			ctx = ctxRef
 		}
 	}
 	if !hasParent && isValidReference(parent) {
@@ -461,4 +463,11 @@ func (t *Tracer) setBaggage(sp *Span, key, value string) {
 // (NB) span must hold the lock before making this call
 func (t *Tracer) isDebugAllowed(operation string) bool {
 	return t.debugThrottler.IsAllowed(operation)
+}
+
+func SelfRef(ctx SpanContext) opentracing.SpanReference {
+	return opentracing.SpanReference{
+		Type:              selfRefType,
+		ReferencedContext: ctx,
+	}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -237,15 +237,14 @@ func (t *Tracer) startSpanWithOptions(
 		}
 		references = append(references, Reference{Type: ref.Type, Context: ctxRef})
 
-		if ref.Type == SelfRef {
-			isSelfRef = true
-			ctx = ctxRef
-			break
-		}
-
 		if !hasParent {
 			parent = ctxRef
 			hasParent = ref.Type == opentracing.ChildOfRef
+		}
+
+		if ref.Type == SelfRef {
+			isSelfRef = true
+			ctx = ctxRef
 		}
 	}
 	if !hasParent && isValidReference(parent) {

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -237,6 +237,27 @@ func (s *tracerSuite) TestRandomIDNotZero() {
 	rng.Seed(1) // for test coverage
 }
 
+func (s *tracerSuite) TestReferenceSelfUsesProvidedContext() {
+	ctx := NewSpanContext(
+		TraceID{
+			High: 1,
+			Low:  2,
+		},
+		SpanID(2),
+		SpanID(1),
+		false,
+		nil,
+	)
+	sp1 := s.tracer.StartSpan(
+		"continued_span",
+		opentracing.SpanReference{
+			Type:              SelfRef,
+			ReferencedContext: ctx,
+		},
+	)
+	s.Equal(ctx, sp1.(*Span).context)
+}
+
 func TestTracerOptions(t *testing.T) {
 	t1, e := time.Parse(time.RFC3339, "2012-11-01T22:08:41+00:00")
 	assert.NoError(t, e)

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -250,10 +250,7 @@ func (s *tracerSuite) TestReferenceSelfUsesProvidedContext() {
 	)
 	sp1 := s.tracer.StartSpan(
 		"continued_span",
-		opentracing.SpanReference{
-			Type:              SelfRef,
-			ReferencedContext: ctx,
-		},
+		SelfRef(ctx),
 	)
 	s.Equal(ctx, sp1.(*Span).context)
 }


### PR DESCRIPTION
refs #397

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- This allows client to initialize a span from an already identified ("offline") context.  

## Short description of the changes
- Introduces a Jaeger specific span reference type `"self"`
- Allows client to pass in an already established `SpanContext`, if so, will use the passed in `SpanContext` for the span instead of generating span/trace ids


--- 
## TODO 
- [x] remove extra pointer, e.g. store ref.ReferencedContext instead
- [x] self reference should continue the loop because a span may have multiple happens-before ancestors
- [x] self reference unit tests
- [x] needs documentation in the comments and a section in the README
- [x] move self ref constants.go is a better place