### PR TITLE
Update default rate

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -348,24 +348,27 @@ func (s *adaptiveSampler) Equal(other Sampler) bool {
 func (s *adaptiveSampler) update(strategies *sampling.PerOperationSamplingStrategies) {
 	s.Lock()
 	defer s.Unlock()
+	newSamplers := map[string]*GuaranteedThroughputProbabilisticSampler{}
 	for _, strategy := range strategies.PerOperationStrategies {
 		operation := strategy.Operation
 		samplingRate := strategy.ProbabilisticSampling.SamplingRate
 		lowerBound := strategies.DefaultLowerBoundTracesPerSecond
 		if sampler, ok := s.samplers[operation]; ok {
 			sampler.update(lowerBound, samplingRate)
+			newSamplers[operation] = sampler
 		} else {
 			sampler := newGuaranteedThroughputProbabilisticSampler(
 				lowerBound,
 				samplingRate,
 			)
-			s.samplers[operation] = sampler
+			newSamplers[operation] = sampler
 		}
 	}
 	s.lowerBound = strategies.DefaultLowerBoundTracesPerSecond
 	if s.defaultSampler.SamplingRate() != strategies.DefaultSamplingProbability {
 		s.defaultSampler = newProbabilisticSampler(strategies.DefaultSamplingProbability)
 	}
+	s.samplers = newSamplers
 }
 
 // -----------------------


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #412 

## Short description of the changes
- On update, collect samplers explicitly requested in the config, and discard all others.
This fixes the problem I encountered, and also the issue that if you remove an entry from strategies, the sampler persists.
- Add unit test covering both types of update. I apologise the test code seems clumsy, maybe I don't understand the framework well.

Downside of this change is that default-rate samplers are discarded even when the default rate doesn't change, so the rate-limiting part will start from scratch. Doing this better seems to require much more extensive changes to remember how things were set up.