### PR TITLE
Default sampling server URL to agent

### DIFF
--- a/config/config_env.go
+++ b/config/config_env.go
@@ -110,6 +110,9 @@ func samplerConfigFromEnv() (*SamplerConfig, error) {
 
 	if e := os.Getenv(envSamplerManagerHostPort); e != "" {
 		sc.SamplingServerURL = e
+	} else if e := os.Getenv(envAgentHost); e != "" {
+		// Fallback if we know the agent host - try the sampling endpoint there
+		sc.SamplingServerURL = fmt.Sprintf("http://%s:%d/sampling", e, jaeger.DefaultSamplingServerPort)
 	}
 
 	if e := os.Getenv(envSamplerMaxOperations); e != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -147,6 +147,21 @@ func TestSamplerConfigFromEnv(t *testing.T) {
 	os.Unsetenv(envSamplerRefreshInterval)
 }
 
+func TestSamplerConfigOnAgentFromEnv(t *testing.T) {
+	// prepare
+	os.Setenv(envAgentHost, "theagent")
+
+	// test
+	cfg, err := FromEnv()
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "http://theagent:5778/sampling", cfg.Sampler.SamplingServerURL)
+
+	// cleanup
+	os.Unsetenv(envAgentHost)
+}
+
 func TestReporterConfigFromEnv(t *testing.T) {
 	// prepare
 	os.Setenv(envReporterMaxQueueSize, "10")

--- a/constants.go
+++ b/constants.go
@@ -85,6 +85,9 @@ const (
 	// DefaultUDPSpanServerPort is the default port to send the spans to, via UDP
 	DefaultUDPSpanServerPort = 6831
 
+	// DefaultSamplingServerPort is the default port to fetch sampling config from, via http
+	DefaultSamplingServerPort = 5778
+
 	// DefaultMaxTagValueLength is the default max length of byte array or string allowed in the tag value.
 	DefaultMaxTagValueLength = 256
 


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #388 

## Short description of the changes
If `JAEGER_AGENT_HOST` is set but `JAEGER_SAMPLER_MANAGER_HOST_PORT` is not, default the sampler manager to point at the agent.
