### PR TITLE
Add "sampleWithoutDebugFlag" option for tracer to decide set/not set debug flag when a span is forced to be sampled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -235,6 +235,7 @@ func (c Configuration) NewTracer(options ...Option) (opentracing.Tracer, io.Clos
 		jaeger.TracerOptions.PoolSpans(opts.poolSpans),
 		jaeger.TracerOptions.ZipkinSharedRPCSpan(opts.zipkinSharedRPCSpan),
 		jaeger.TracerOptions.MaxTagValueLength(opts.maxTagValueLength),
+		jaeger.TracerOptions.NoDebugFlagOnForcedSampling(opts.noDebugFlagOnForcedSampling),
 	}
 
 	for _, tag := range opts.tags {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -550,6 +550,19 @@ func TestNewTracer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNewTracerWithNoDebugFlagOnForcedSampling(t *testing.T) {
+	cfg := &Configuration{ServiceName: "my-service"}
+	tracer, closer, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger), NoDebugFlagOnForcedSampling(true))
+	defer closer.Close()
+
+	span := tracer.StartSpan("testSpan").(*jaeger.Span)
+	ext.SamplingPriority.Set(span, 1)
+
+	assert.NoError(t, err)
+	assert.False(t, span.SpanContext().IsDebug())
+	assert.True(t, span.SpanContext().IsSampled())
+}
+
 func TestNewTracerWithoutServiceName(t *testing.T) {
 	cfg := &Configuration{}
 	_, _, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger))

--- a/config/options.go
+++ b/config/options.go
@@ -26,19 +26,20 @@ type Option func(c *Options)
 
 // Options control behavior of the client.
 type Options struct {
-	metrics             metrics.Factory
-	logger              jaeger.Logger
-	reporter            jaeger.Reporter
-	sampler             jaeger.Sampler
-	contribObservers    []jaeger.ContribObserver
-	observers           []jaeger.Observer
-	gen128Bit           bool
-	poolSpans           bool
-	zipkinSharedRPCSpan bool
-	maxTagValueLength   int
-	tags                []opentracing.Tag
-	injectors           map[interface{}]jaeger.Injector
-	extractors          map[interface{}]jaeger.Extractor
+	metrics                     metrics.Factory
+	logger                      jaeger.Logger
+	reporter                    jaeger.Reporter
+	sampler                     jaeger.Sampler
+	contribObservers            []jaeger.ContribObserver
+	observers                   []jaeger.Observer
+	gen128Bit                   bool
+	poolSpans                   bool
+	zipkinSharedRPCSpan         bool
+	maxTagValueLength           int
+	noDebugFlagOnForcedSampling bool
+	tags                        []opentracing.Tag
+	injectors                   map[interface{}]jaeger.Injector
+	extractors                  map[interface{}]jaeger.Extractor
 }
 
 // Metrics creates an Option that initializes Metrics in the tracer,
@@ -114,6 +115,14 @@ func ZipkinSharedRPCSpan(zipkinSharedRPCSpan bool) Option {
 func MaxTagValueLength(maxTagValueLength int) Option {
 	return func(c *Options) {
 		c.maxTagValueLength = maxTagValueLength
+	}
+}
+
+// NoDebugFlagOnForcedSampling can be used to decide whether debug flag will be set or not
+// when calling span.setSamplingPriority to force sample a span.
+func NoDebugFlagOnForcedSampling(noDebugFlagOnForcedSampling bool) Option {
+	return func(c *Options) {
+		c.noDebugFlagOnForcedSampling = noDebugFlagOnForcedSampling
 	}
 }
 

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -41,6 +41,7 @@ func TestApplyOptions(t *testing.T) {
 		PoolSpans(true),
 		ZipkinSharedRPCSpan(true),
 		MaxTagValueLength(1024),
+		NoDebugFlagOnForcedSampling(true),
 	)
 	assert.Equal(t, jaeger.StdLogger, opts.logger)
 	assert.Equal(t, sampler, opts.sampler)
@@ -50,6 +51,7 @@ func TestApplyOptions(t *testing.T) {
 	assert.True(t, opts.gen128Bit)
 	assert.True(t, opts.poolSpans)
 	assert.True(t, opts.zipkinSharedRPCSpan)
+	assert.True(t, opts.noDebugFlagOnForcedSampling)
 	assert.Equal(t, 1024, opts.maxTagValueLength)
 }
 

--- a/span.go
+++ b/span.go
@@ -312,7 +312,10 @@ func setSamplingPriority(s *Span, value interface{}) bool {
 		s.context.flags = s.context.flags & (^flagSampled)
 		return true
 	}
-	if s.tracer.isDebugAllowed(s.operationName) {
+	if s.tracer.options.noDebugFlagOnForcedSampling {
+		s.context.flags = s.context.flags | flagSampled
+		return true
+	} else if s.tracer.isDebugAllowed(s.operationName) {
 		s.context.flags = s.context.flags | flagDebug | flagSampled
 		return true
 	}
@@ -321,5 +324,7 @@ func setSamplingPriority(s *Span, value interface{}) bool {
 
 // EnableFirehose enables firehose flag on the span context
 func EnableFirehose(s *Span) {
+	s.Lock()
+	defer s.Unlock()
 	s.context.flags |= flagFirehose
 }

--- a/tracer.go
+++ b/tracer.go
@@ -47,10 +47,11 @@ type Tracer struct {
 	randomNumber func() uint64
 
 	options struct {
-		gen128Bit            bool // whether to generate 128bit trace IDs
-		zipkinSharedRPCSpan  bool
-		highTraceIDGenerator func() uint64 // custom high trace ID generator
-		maxTagValueLength    int
+		gen128Bit                   bool // whether to generate 128bit trace IDs
+		zipkinSharedRPCSpan         bool
+		highTraceIDGenerator        func() uint64 // custom high trace ID generator
+		maxTagValueLength           int
+		noDebugFlagOnForcedSampling bool
 		// more options to come
 	}
 	// allocator of Span objects

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -126,6 +126,12 @@ func (tracerOptions) Gen128Bit(gen128Bit bool) TracerOption {
 	}
 }
 
+func (tracerOptions) NoDebugFlagOnForcedSampling(noDebugFlagOnForcedSampling bool) TracerOption {
+	return func(tracer *Tracer) {
+		tracer.options.noDebugFlagOnForcedSampling = noDebugFlagOnForcedSampling
+	}
+}
+
 func (tracerOptions) HighTraceIDGenerator(highTraceIDGenerator func() uint64) TracerOption {
 	return func(tracer *Tracer) {
 		tracer.options.highTraceIDGenerator = highTraceIDGenerator

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -278,6 +278,7 @@ func TestTracerOptions(t *testing.T) {
 		TracerOptions.RandomNumber(rnd),
 		TracerOptions.PoolSpans(true),
 		TracerOptions.Tag("tag_key", "tag_value"),
+		TracerOptions.NoDebugFlagOnForcedSampling(true),
 	)
 	defer closer.Close()
 
@@ -289,6 +290,7 @@ func TestTracerOptions(t *testing.T) {
 	assert.Equal(t, uint64(1), tracer.randomNumber()) // always 1
 	assert.Equal(t, true, isPoolAllocator(tracer.spanAllocator))
 	assert.Equal(t, opentracing.Tag{Key: "tag_key", Value: "tag_value"}, tracer.Tags()[0])
+	assert.True(t, tracer.options.noDebugFlagOnForcedSampling)
 }
 
 func TestInjectorExtractorOptions(t *testing.T) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #422 

## Short description of the changes
- Add "sampleWithoutDebugFlag" option when initialize tracer
- Update setSamplingPriority logic to set debug flag accordingly
- Avoid race condition update set firehose flag
