### PR TITLE
Remove go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,16 @@ matrix:
   - go: 1.12.x
     env:
     - TESTS=true
-    - COVERAGE=true
-    - GO111MODULE=on
-  - go: 1.12.x
-    env:
-    - CROSSDOCK=true
-    - GO111MODULE=on
-  - go: 1.12.x
-    env:
-    - TESTS=true
     - USE_DEP=true
+    - COVERAGE=true
+  - go: 1.12.x
+    env:
+    - USE_DEP=true
+    - CROSSDOCK=true
   - go: 1.12.x
     env:
     - TESTS=true
+    - USE_DEP=false
     - USE_GLIDE=true
   - go: 1.11.x
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,20 +19,23 @@ file for details.
 
 ## Getting Started
 
-This library uses Go modules to manage dependencies.
+This library uses [dep](https://golang.github.io/dep/) to manage dependencies.
 
-To get started, clone the Git repository into any location (does not need to be under `$GOPATH`):
+To get started, make sure you clone the Git repository into the correct location
+`github.com/uber/jaeger-client-go` relative to `$GOPATH`:
 
 ```
-cd you-dev-root
+mkdir -p $GOPATH/src/github.com/uber
+cd $GOPATH/src/github.com/uber
 git clone git@github.com:jaegertracing/jaeger-client-go.git jaeger-client-go
 cd jaeger-client-go
 git submodule update --init --recursive
 ```
 
-Go will download dependencies automatically when you run the tests:
+Then install dependencies and run the tests:
 
 ```
+make install
 make test
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ALL_SRC := $(shell find . -name "*.go" | grep -v -e vendor -e thrift-gen -e ./th
         -e ".*/_.*" \
         -e ".*/mocks.*")
 
+USE_DEP := true
+
 -include crossdock/rules.mk
 
 RACE=-race

--- a/README.md
+++ b/README.md
@@ -15,14 +15,27 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Installation
 
-We recommended using [semantic versioning](http://semver.org/) when including this library into an application. For example, Jaeger backend imports this library like this (if using Dep):
+We recommended using a dependency manager like [dep](https://golang.github.io/dep/)
+and [semantic versioning](http://semver.org/) when including this library into an application.
+For example, Jaeger backend imports this library like this:
 
-```yaml
-- package: github.com/uber/jaeger-client-go
-  version: ^2.7.0
+```toml
+[[constraint]]
+  name = "github.com/uber/jaeger-client-go"
+  version = "2.17"
 ```
 
-If you instead want to use the latest version in `master`, you can pull it via `go get github.com/uber/jaeger-client-go`.
+If you instead want to use the latest version in `master`, you can pull it via `go get`.
+Note that during `go get` you may see build errors due to incompatible dependencies, which is why
+we recommend using semantic versions for dependencies.  The error  may be fixed by running
+`make install` (it will install `dep` if you don't have it):
+
+```shell
+go get -u github.com/uber/jaeger-client-go/
+cd $GOPATH/src/github.com/uber/jaeger-client-go/
+git submodule update --init --recursive
+make install
+```
 
 ## Initialization
 


### PR DESCRIPTION
According to https://github.com/jaegertracing/jaeger-lib/pull/75#issuecomment-528639764, enabling go modules is more complicated when the library is on a version above 1.x, which is the case with jaeger-client-go and jaeger-lib.

For now, removing go modules. Will revisit in the future along with potential renaming of the path from /uber/ to /jaegertracing/

Reopens ##382