### PR TITLE
Allow config.FromEnv() to enrich an existing config object

### DIFF
--- a/config/config_env.go
+++ b/config/config_env.go
@@ -52,7 +52,10 @@ const (
 // FromEnv uses environment variables to set the tracer's Configuration
 func FromEnv() (*Configuration, error) {
 	c := &Configuration{}
+	return c.FromEnv()
+}
 
+func (c *Configuration) FromEnv() (*Configuration, error) {
 	if e := os.Getenv(envServiceName); e != "" {
 		c.ServiceName = e
 	}

--- a/config/config_env.go
+++ b/config/config_env.go
@@ -55,6 +55,7 @@ func FromEnv() (*Configuration, error) {
 	return c.FromEnv()
 }
 
+// FromEnv uses environment variables and overrides existing tracer's Configuration
 func (c *Configuration) FromEnv() (*Configuration, error) {
 	if e := os.Getenv(envServiceName); e != "" {
 		c.ServiceName = e

--- a/config/config_env.go
+++ b/config/config_env.go
@@ -80,13 +80,21 @@ func (c *Configuration) FromEnv() (*Configuration, error) {
 		c.Tags = parseTags(e)
 	}
 
-	if s, err := samplerConfigFromEnv(); err == nil {
+	if c.Sampler == nil {
+		c.Sampler = &SamplerConfig{}
+	}
+
+	if s, err := c.Sampler.samplerConfigFromEnv(); err == nil {
 		c.Sampler = s
 	} else {
 		return nil, errors.Wrap(err, "cannot obtain sampler config from env")
 	}
 
-	if r, err := reporterConfigFromEnv(); err == nil {
+	if c.Reporter == nil {
+		c.Reporter = &ReporterConfig{}
+	}
+
+	if r, err := c.Reporter.reporterConfigFromEnv(); err == nil {
 		c.Reporter = r
 	} else {
 		return nil, errors.Wrap(err, "cannot obtain reporter config from env")
@@ -96,9 +104,7 @@ func (c *Configuration) FromEnv() (*Configuration, error) {
 }
 
 // samplerConfigFromEnv creates a new SamplerConfig based on the environment variables
-func samplerConfigFromEnv() (*SamplerConfig, error) {
-	sc := &SamplerConfig{}
-
+func (sc *SamplerConfig) samplerConfigFromEnv() (*SamplerConfig, error) {
 	if e := os.Getenv(envSamplerType); e != "" {
 		sc.Type = e
 	}
@@ -138,9 +144,7 @@ func samplerConfigFromEnv() (*SamplerConfig, error) {
 }
 
 // reporterConfigFromEnv creates a new ReporterConfig based on the environment variables
-func reporterConfigFromEnv() (*ReporterConfig, error) {
-	rc := &ReporterConfig{}
-
+func (rc *ReporterConfig) reporterConfigFromEnv() (*ReporterConfig, error) {
 	if e := os.Getenv(envReporterMaxQueueSize); e != "" {
 		if value, err := strconv.ParseInt(e, 10, 0); err == nil {
 			rc.QueueSize = int(value)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -85,6 +85,138 @@ func TestServiceNameFromEnv(t *testing.T) {
 	os.Unsetenv(envServiceName)
 }
 
+
+func TestConfigFromEnv(t *testing.T) {
+	os.Setenv(envServiceName, "my-service")
+	os.Setenv(envDisabled, "false")
+	os.Setenv(envRPCMetrics, "true")
+	os.Setenv(envTags, "KEY=VALUE")
+
+	cfg := &Configuration{
+		ServiceName:         "my-config-service",
+		Disabled:            true,
+		RPCMetrics:          false,
+		Tags:                []opentracing.Tag{{"KEY-CONFIG","KEY-VALUE"}},
+	}
+
+	cfg, err := cfg.FromEnv()
+	assert.NoError(t, err)
+	assert.Equal(t, "my-service", cfg.ServiceName)
+	assert.Equal(t, false, cfg.Disabled)
+	assert.Equal(t, true, cfg.RPCMetrics)
+	assert.Equal(t, "KEY", cfg.Tags[0].Key)
+	assert.Equal(t, "VALUE", cfg.Tags[0].Value)
+
+	os.Unsetenv(envServiceName)
+	os.Unsetenv(envDisabled)
+	os.Unsetenv(envRPCMetrics)
+	os.Unsetenv(envTags)
+}
+
+func TestSamplerConfig(t *testing.T) {
+	// prepare
+	os.Setenv(envSamplerType, "const")
+	os.Setenv(envSamplerParam, "1")
+	os.Setenv(envSamplerManagerHostPort, "http://themaster")
+	os.Setenv(envSamplerMaxOperations, "10")
+	os.Setenv(envSamplerRefreshInterval, "1m1s") // 61 seconds
+
+	sc := SamplerConfig{
+		Type:                    "const-sample-config",
+		Param:                   2,
+		SamplingServerURL:       "http://themaster-sample-config",
+		MaxOperations:           20,
+		SamplingRefreshInterval: 2,
+	}
+
+	// test
+	cfg, err := sc.samplerConfigFromEnv()
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "const", cfg.Type)
+	assert.Equal(t, float64(1), cfg.Param)
+	assert.Equal(t, "http://themaster", cfg.SamplingServerURL)
+	assert.Equal(t, int(10), cfg.MaxOperations)
+	assert.Equal(t, 61000000000, int(cfg.SamplingRefreshInterval))
+
+	// cleanup
+	os.Unsetenv(envSamplerType)
+	os.Unsetenv(envSamplerParam)
+	os.Unsetenv(envSamplerManagerHostPort)
+	os.Unsetenv(envSamplerMaxOperations)
+	os.Unsetenv(envSamplerRefreshInterval)
+
+}
+
+func TestReporter(t *testing.T) {
+	// prepare
+	os.Setenv(envReporterMaxQueueSize, "10")
+	os.Setenv(envReporterFlushInterval, "1m1s") // 61 seconds
+	os.Setenv(envReporterLogSpans, "true")
+	os.Setenv(envAgentHost, "nonlocalhost")
+	os.Setenv(envAgentPort, "6832")
+	os.Setenv(envUser, "user")
+	os.Setenv(envPassword, "password")
+
+	rc := ReporterConfig{
+		QueueSize:           20,
+		BufferFlushInterval: 2,
+		LogSpans:            false,
+		LocalAgentHostPort:  "localhost01",
+		CollectorEndpoint:   "9999",
+		User:                "user01",
+		Password:            "password01",
+	}
+
+	// test
+	cfg, err := rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, int(10), cfg.QueueSize)
+	assert.Equal(t, 61000000000, int(cfg.BufferFlushInterval))
+	assert.Equal(t, true, cfg.LogSpans)
+	assert.Equal(t, "nonlocalhost:6832", cfg.LocalAgentHostPort)
+	assert.Equal(t, "user01", cfg.User)
+	assert.Equal(t,"password01", cfg.Password)
+
+	// verifying JAEGAR-ENDPOINT env set
+	os.Setenv(envEndpoint, "http://1.2.3.4:5678/api/traces")
+	os.Setenv(envUser, "user")
+	os.Setenv(envPassword, "password")
+
+	rc = ReporterConfig{
+		QueueSize:           20,
+		BufferFlushInterval: 2,
+		LogSpans:            false,
+		LocalAgentHostPort:  "localhost",
+		CollectorEndpoint:   "9999",
+		User:                "user",
+		Password:            "password",
+	}
+
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "http://1.2.3.4:5678/api/traces", cfg.CollectorEndpoint)
+	assert.Equal(t, "localhost", cfg.LocalAgentHostPort)
+	assert.Equal(t, "user", cfg.User)
+	assert.Equal(t,"password", cfg.Password)
+
+
+
+	// cleanup
+	os.Unsetenv(envReporterMaxQueueSize)
+	os.Unsetenv(envReporterFlushInterval)
+	os.Unsetenv(envReporterLogSpans)
+	os.Unsetenv(envEndpoint)
+	os.Unsetenv(envUser)
+	os.Unsetenv(envPassword)
+	os.Unsetenv(envAgentHost)
+	os.Unsetenv(envAgentPort)
+}
+
 func TestFromEnv(t *testing.T) {
 	os.Setenv(envServiceName, "my-service")
 	os.Setenv(envDisabled, "false")
@@ -102,6 +234,7 @@ func TestFromEnv(t *testing.T) {
 	os.Unsetenv(envServiceName)
 	os.Unsetenv(envDisabled)
 	os.Unsetenv(envRPCMetrics)
+	os.Unsetenv(envTags)
 }
 
 func TestNoServiceNameFromEnv(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,13 +87,6 @@ func TestServiceNameFromEnv(t *testing.T) {
 
 
 func TestConfigFromEnv(t *testing.T) {
-	//Prepare
-	os.Setenv(envServiceName, "my-service")
-	os.Setenv(envDisabled, "false")
-	os.Setenv(envRPCMetrics, "true")
-	os.Setenv(envTags, "KEY=VALUE")
-
-	//existing config data
 	cfg := &Configuration{
 		ServiceName:         "my-config-service",
 		Disabled:            true,
@@ -106,13 +99,30 @@ func TestConfigFromEnv(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify
+	assert.Equal(t, "my-config-service", cfg.ServiceName)
+	assert.Equal(t, true, cfg.Disabled)
+	assert.Equal(t, false, cfg.RPCMetrics)
+	assert.Equal(t, "KEY01", cfg.Tags[0].Key)
+	assert.Equal(t, "VALUE01", cfg.Tags[0].Value)
+
+	// prepare
+	os.Setenv(envServiceName, "my-service")
+	os.Setenv(envDisabled, "false")
+	os.Setenv(envRPCMetrics, "true")
+	os.Setenv(envTags, "KEY=VALUE")
+
+	// test with env set
+	cfg, err = cfg.FromEnv()
+	assert.NoError(t, err)
+
+	// verify
 	assert.Equal(t, "my-service", cfg.ServiceName)
 	assert.Equal(t, false, cfg.Disabled)
 	assert.Equal(t, true, cfg.RPCMetrics)
 	assert.Equal(t, "KEY", cfg.Tags[0].Key)
 	assert.Equal(t, "VALUE", cfg.Tags[0].Value)
 
-	//cleanup
+	// cleanup
 	os.Unsetenv(envServiceName)
 	os.Unsetenv(envDisabled)
 	os.Unsetenv(envRPCMetrics)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -85,13 +85,12 @@ func TestServiceNameFromEnv(t *testing.T) {
 	os.Unsetenv(envServiceName)
 }
 
-
 func TestConfigFromEnv(t *testing.T) {
 	cfg := &Configuration{
-		ServiceName:         "my-config-service",
-		Disabled:            true,
-		RPCMetrics:          false,
-		Tags:                []opentracing.Tag{opentracing.Tag{Key: "KEY01", Value: "VALUE01"}},
+		ServiceName: "my-config-service",
+		Disabled:    true,
+		RPCMetrics:  false,
+		Tags:        []opentracing.Tag{opentracing.Tag{Key: "KEY01", Value: "VALUE01"}},
 	}
 
 	// test
@@ -197,7 +196,7 @@ func TestReporter(t *testing.T) {
 	assert.Equal(t, true, cfg.LogSpans)
 	assert.Equal(t, "nonlocalhost:6832", cfg.LocalAgentHostPort)
 	assert.Equal(t, "user01", cfg.User)
-	assert.Equal(t,"password01", cfg.Password)
+	assert.Equal(t, "password01", cfg.Password)
 
 	// Prepare
 	os.Setenv(envEndpoint, "http://1.2.3.4:5678/api/traces")
@@ -223,7 +222,7 @@ func TestReporter(t *testing.T) {
 	assert.Equal(t, "http://1.2.3.4:5678/api/traces", cfg.CollectorEndpoint)
 	assert.Equal(t, "localhost", cfg.LocalAgentHostPort)
 	assert.Equal(t, "user", cfg.User)
-	assert.Equal(t,"password", cfg.Password)
+	assert.Equal(t, "password", cfg.Password)
 
 	// cleanup
 	os.Unsetenv(envReporterMaxQueueSize)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,7 +90,7 @@ func TestConfigFromEnv(t *testing.T) {
 		ServiceName: "my-config-service",
 		Disabled:    true,
 		RPCMetrics:  false,
-		Tags:        []opentracing.Tag{opentracing.Tag{Key: "KEY01", Value: "VALUE01"}},
+		Tags:        []opentracing.Tag{{Key: "KEY01", Value: "VALUE01"}},
 	}
 
 	// test

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,26 +87,32 @@ func TestServiceNameFromEnv(t *testing.T) {
 
 
 func TestConfigFromEnv(t *testing.T) {
+	//Prepare
 	os.Setenv(envServiceName, "my-service")
 	os.Setenv(envDisabled, "false")
 	os.Setenv(envRPCMetrics, "true")
 	os.Setenv(envTags, "KEY=VALUE")
 
+	//existing config data
 	cfg := &Configuration{
 		ServiceName:         "my-config-service",
 		Disabled:            true,
 		RPCMetrics:          false,
-		Tags:                []opentracing.Tag{{"KEY-CONFIG","KEY-VALUE"}},
+		Tags:                []opentracing.Tag{opentracing.Tag{Key: "KEY01", Value: "VALUE01"}},
 	}
 
+	// test
 	cfg, err := cfg.FromEnv()
 	assert.NoError(t, err)
+
+	// verify
 	assert.Equal(t, "my-service", cfg.ServiceName)
 	assert.Equal(t, false, cfg.Disabled)
 	assert.Equal(t, true, cfg.RPCMetrics)
 	assert.Equal(t, "KEY", cfg.Tags[0].Key)
 	assert.Equal(t, "VALUE", cfg.Tags[0].Value)
 
+	//cleanup
 	os.Unsetenv(envServiceName)
 	os.Unsetenv(envDisabled)
 	os.Unsetenv(envRPCMetrics)
@@ -121,6 +127,7 @@ func TestSamplerConfig(t *testing.T) {
 	os.Setenv(envSamplerMaxOperations, "10")
 	os.Setenv(envSamplerRefreshInterval, "1m1s") // 61 seconds
 
+	//existing SamplerConfig data
 	sc := SamplerConfig{
 		Type:                    "const-sample-config",
 		Param:                   2,
@@ -159,6 +166,7 @@ func TestReporter(t *testing.T) {
 	os.Setenv(envUser, "user")
 	os.Setenv(envPassword, "password")
 
+	// Existing ReporterConfig data
 	rc := ReporterConfig{
 		QueueSize:           20,
 		BufferFlushInterval: 2,
@@ -181,11 +189,12 @@ func TestReporter(t *testing.T) {
 	assert.Equal(t, "user01", cfg.User)
 	assert.Equal(t,"password01", cfg.Password)
 
-	// verifying JAEGAR-ENDPOINT env set
+	// Prepare
 	os.Setenv(envEndpoint, "http://1.2.3.4:5678/api/traces")
 	os.Setenv(envUser, "user")
 	os.Setenv(envPassword, "password")
 
+	// Existing ReprterConfig data for JAEGAR-ENDPOINT validation check
 	rc = ReporterConfig{
 		QueueSize:           20,
 		BufferFlushInterval: 2,
@@ -196,15 +205,15 @@ func TestReporter(t *testing.T) {
 		Password:            "password",
 	}
 
+	// test
 	cfg, err = rc.reporterConfigFromEnv()
 	assert.NoError(t, err)
 
+	// verify
 	assert.Equal(t, "http://1.2.3.4:5678/api/traces", cfg.CollectorEndpoint)
 	assert.Equal(t, "localhost", cfg.LocalAgentHostPort)
 	assert.Equal(t, "user", cfg.User)
 	assert.Equal(t,"password", cfg.Password)
-
-
 
 	// cleanup
 	os.Unsetenv(envReporterMaxQueueSize)


### PR DESCRIPTION

## Which problem is this PR solving?
- allow the user to override that configuration via env vars

## Short description of the changes
- Added another method with config receiver and modified the existing method to call the method with config receiver.

Signed-off-by: vineeth <vineeth.pothulapati@aquasec.com>

Resolves: #430 
