### PR TITLE
log/zap: Report whether a trace was sampled

### DIFF
--- a/log/zap/field.go
+++ b/log/zap/field.go
@@ -56,5 +56,6 @@ func (t trace) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	}
 	enc.AddString("span", j.SpanID().String())
 	enc.AddString("trace", j.TraceID().String())
+	enc.AddBool("sampled", j.IsSampled())
 	return nil
 }

--- a/log/zap/field_test.go
+++ b/log/zap/field_test.go
@@ -46,7 +46,7 @@ func TestTraceField(t *testing.T) {
 		}
 		assert.Equal(
 			t,
-			map[string]struct{}{"span": {}, "trace": {}},
+			map[string]struct{}{"span": {}, "trace": {}, "sampled": {}},
 			keys,
 			"Expected to log span and trace IDs.",
 		)


### PR DESCRIPTION
When a trace is logged, we don't report whether it was sampled, so users
don't know whether they can look it up in the system.

This changes log/zap to log this information.

Resolves #444
