### PR TITLE
Refactor remote sampler for better extensibility

### DIFF
--- a/experimental/sampler_custom_updater_test.go
+++ b/experimental/sampler_custom_updater_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package experimental
 
 import (

--- a/experimental/sampler_custom_updater_test.go
+++ b/experimental/sampler_custom_updater_test.go
@@ -1,0 +1,173 @@
+package experimental
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/testutils"
+	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
+)
+
+type customSamplingStrategyResponse struct {
+	sampling.SamplingStrategyResponse
+
+	TagMatching *TagMatchingSamplingStrategy `json:"tagEqualitySampling"`
+}
+
+type customSamplingStrategyParser struct{}
+
+func (p *customSamplingStrategyParser) Parse(response []byte) (interface{}, error) {
+	strategy := new(customSamplingStrategyResponse)
+	err := json.Unmarshal(response, strategy)
+	if err != nil {
+		return nil, err
+	}
+	return strategy, err
+}
+
+type customSamplerUpdater struct {
+	samplerLock     sync.Mutex
+	mainSampler     jaeger.SamplerV2
+	defaultUpdaters []jaeger.SamplerUpdater
+}
+
+func newCustomSamplerUpdater() *customSamplerUpdater {
+	return &customSamplerUpdater{
+		defaultUpdaters: []jaeger.SamplerUpdater{
+			new(jaeger.ProbabilisticSamplerUpdater),
+			new(jaeger.RateLimitingSamplerUpdater),
+		},
+	}
+}
+
+func (u *customSamplerUpdater) Update(sampler jaeger.SamplerV2, strategy interface{}) (jaeger.SamplerV2, error) {
+	u.samplerLock.Lock()
+	defer u.samplerLock.Unlock()
+
+	// when we're called the first time, the sampler will be the original sampler
+	if u.mainSampler == nil {
+		u.mainSampler = sampler
+	}
+
+	if resp, ok := strategy.(*customSamplingStrategyResponse); ok {
+		sampler, err := u.applyDefaultUpdaters(u.mainSampler, &resp.SamplingStrategyResponse)
+		if err != nil {
+			return nil, err
+		}
+		u.mainSampler = sampler
+		if resp.TagMatching == nil {
+			return sampler, nil
+		}
+		tagSampler := NewTagMatchingSamplerFromStrategy(*resp.TagMatching)
+		return NewPrioritySampler(tagSampler, u.mainSampler), nil
+	}
+	return nil, fmt.Errorf("unsupported sampling strategy response %+v", strategy)
+}
+
+func (u *customSamplerUpdater) applyDefaultUpdaters(sampler jaeger.SamplerV2, res *sampling.SamplingStrategyResponse) (jaeger.SamplerV2, error) {
+	for _, updater := range u.defaultUpdaters {
+		sampler, err := updater.Update(sampler, res)
+		if err != nil {
+			return nil, err
+		}
+		if sampler != nil {
+			return sampler, nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported sampling strategy type %v", res.GetStrategyType())
+}
+
+type customTestObjects struct {
+	agent   *testutils.MockAgent
+	sampler *jaeger.RemotelyControlledSampler
+	tracer  *jaeger.Tracer
+	updater *customSamplerUpdater
+}
+
+func withAgent(t *testing.T, fn func(objects customTestObjects)) {
+	agent, err := testutils.StartMockAgent()
+	require.NoError(t, err)
+	defer agent.Close()
+
+	updater := newCustomSamplerUpdater()
+	sampler := jaeger.NewRemotelyControlledSampler(
+		"service",
+		jaeger.SamplerOptions.SamplingServerURL("http://"+agent.SamplingServerAddr()),
+		jaeger.SamplerOptions.SamplingRefreshInterval(time.Minute),
+		jaeger.SamplerOptions.SamplingStrategyParser(new(customSamplingStrategyParser)),
+		jaeger.SamplerOptions.Updaters(updater),
+	)
+	sampler.Close() // stop timer-based updates, we want to call them manually
+
+	tracer, closer := jaeger.NewTracer("service", sampler, jaeger.NewNullReporter())
+	defer closer.Close()
+
+	fn(customTestObjects{agent: agent, sampler: sampler, tracer: tracer.(*jaeger.Tracer), updater: updater})
+}
+
+func TestCustomRemoteSampler(t *testing.T) {
+	mainStrategy := sampling.SamplingStrategyResponse{
+		StrategyType: sampling.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+			SamplingRate: 0.5,
+		},
+	}
+	mainSampler, _ := jaeger.NewProbabilisticSampler(0.5)
+	neverSampleStrategy := sampling.SamplingStrategyResponse{
+		StrategyType: sampling.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+			SamplingRate: 0.0,
+		},
+	}
+	neverSampler, _ := jaeger.NewProbabilisticSampler(0.0)
+	tagStrategy := &TagMatchingSamplingStrategy{
+		Key: "theWho",
+		Values: map[string]TagMatcher{
+			"Bender": {
+				Firehose: true,
+			},
+		},
+	}
+
+	assertSampler := func(t *testing.T, expected jaeger.Sampler, actual jaeger.SamplerV2) {
+		assert.IsType(t, expected, actual)
+		assert.True(t, expected.Equal(actual.(jaeger.Sampler)),
+			"sampler.Equal: want=%+v, have=%+v", expected, actual)
+	}
+
+	withAgent(t, func(obj customTestObjects) {
+		// step 1 - probabilistic sampler
+		obj.agent.AddSamplingStrategy("service", &mainStrategy)
+		obj.sampler.UpdateSampler()
+		assertSampler(t, mainSampler, obj.sampler.GetSampler())
+
+		// step 2 - combine with
+		obj.agent.AddSamplingStrategy("service", &customSamplingStrategyResponse{
+			SamplingStrategyResponse: neverSampleStrategy,
+			TagMatching:              tagStrategy,
+		})
+		obj.sampler.UpdateSampler()
+		assert.IsType(t, new(PrioritySampler), obj.sampler.GetSampler())
+		assertSampler(t, neverSampler, obj.updater.mainSampler)
+
+		span := obj.tracer.StartSpan("span")
+		assert.False(t, span.Context().(jaeger.SpanContext).IsSampled())
+		span.SetTag("theWho", "Bender")
+		assert.True(t, span.Context().(jaeger.SpanContext).IsSampled())
+
+		// step 3 - back to probabilistic sampler only
+		obj.agent.AddSamplingStrategy("service", &mainStrategy)
+		obj.sampler.UpdateSampler()
+
+		assert.IsType(t, mainSampler, obj.sampler.GetSampler())
+		assert.True(t, mainSampler.Equal(obj.sampler.GetSampler().(jaeger.Sampler)),
+			"sampler.Equal: want=%+v, have=%+v", mainSampler, obj.sampler.GetSampler())
+
+	})
+}

--- a/experimental/sampler_custom_updater_test.go
+++ b/experimental/sampler_custom_updater_test.go
@@ -161,7 +161,7 @@ func TestCustomRemoteSampler(t *testing.T) {
 		obj.sampler.UpdateSampler()
 		assertSampler(t, mainSampler, obj.sampler.GetSampler())
 
-		// step 2 - combine with
+		// step 2 - combine with tag matching sampler
 		obj.agent.AddSamplingStrategy("service", &customSamplingStrategyResponse{
 			SamplingStrategyResponse: neverSampleStrategy,
 			TagMatching:              tagStrategy,
@@ -178,10 +178,6 @@ func TestCustomRemoteSampler(t *testing.T) {
 		// step 3 - back to probabilistic sampler only
 		obj.agent.AddSamplingStrategy("service", &mainStrategy)
 		obj.sampler.UpdateSampler()
-
-		assert.IsType(t, mainSampler, obj.sampler.GetSampler())
-		assert.True(t, mainSampler.Equal(obj.sampler.GetSampler().(jaeger.Sampler)),
-			"sampler.Equal: want=%+v, have=%+v", mainSampler, obj.sampler.GetSampler())
-
+		assertSampler(t, mainSampler, obj.sampler.GetSampler())
 	})
 }

--- a/experimental/tag_sampler.go
+++ b/experimental/tag_sampler.go
@@ -57,7 +57,8 @@ func NewTagMatchingSampler(tagKey string, matchers []TagMatcher) *TagMatchingSam
 	}
 }
 
-type tagMatchingSamplingStrategy struct {
+// TagMatchingSamplingStrategy defines JSON format for TagMatchingSampler strategy.
+type TagMatchingSamplingStrategy struct {
 	Key      string       `json:"key"`
 	Matchers []TagMatcher `json:"matchers"`
 	// legacy format as map
@@ -94,16 +95,20 @@ type tagMatchingSamplingStrategy struct {
 // When a given tag value appears multiple time, then last one in "matchers" wins,
 // and the one in "values" wins overall.
 func NewTagMatchingSamplerFromStrategyJSON(jsonString []byte) (*TagMatchingSampler, error) {
-	var strategy tagMatchingSamplingStrategy
+	var strategy TagMatchingSamplingStrategy
 	err := json.Unmarshal(jsonString, &strategy)
 	if err != nil {
 		return nil, err
 	}
+	return NewTagMatchingSamplerFromStrategy(strategy), nil
+}
+
+func NewTagMatchingSamplerFromStrategy(strategy TagMatchingSamplingStrategy) *TagMatchingSampler {
 	for k, v := range strategy.Values {
 		v.TagValue = k
 		strategy.Matchers = append(strategy.Matchers, v)
 	}
-	return NewTagMatchingSampler(strategy.Key, strategy.Matchers), nil
+	return NewTagMatchingSampler(strategy.Key, strategy.Matchers)
 }
 
 func (s *TagMatchingSampler) decide(span *jaeger.Span, value interface{}) jaeger.SamplingDecision {

--- a/experimental/tag_sampler.go
+++ b/experimental/tag_sampler.go
@@ -103,6 +103,7 @@ func NewTagMatchingSamplerFromStrategyJSON(jsonString []byte) (*TagMatchingSampl
 	return NewTagMatchingSamplerFromStrategy(strategy), nil
 }
 
+// NewTagMatchingSamplerFromStrategy instantiates TagMatchingSampler from a strategy.
 func NewTagMatchingSamplerFromStrategy(strategy TagMatchingSamplingStrategy) *TagMatchingSampler {
 	for k, v := range strategy.Values {
 		v.TagValue = k

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -146,6 +146,7 @@ func (s *RemotelyControlledSampler) pollControllerWithTicker(ticker *time.Ticker
 	}
 }
 
+// GetSampler returns the currently active sampler.
 func (s *RemotelyControlledSampler) GetSampler() SamplerV2 {
 	s.Lock()
 	defer s.Unlock()

--- a/sampler_remote_options.go
+++ b/sampler_remote_options.go
@@ -33,6 +33,8 @@ type samplerOptions struct {
 	logger                  Logger
 	samplingServerURL       string
 	samplingRefreshInterval time.Duration
+	samplingFetcher         SamplingStrategyFetcher
+	samplingParser          SamplingStrategyParser
 	updaters                []SamplerUpdater
 }
 
@@ -84,7 +86,7 @@ func (samplerOptions) SamplingRefreshInterval(samplingRefreshInterval time.Durat
 }
 
 // Updaters creates a SamplerOption that initializes sampler updaters.
-func (samplerOptions) Updaters(updaters []SamplerUpdater) SamplerOption {
+func (samplerOptions) Updaters(updaters ...SamplerUpdater) SamplerOption {
 	return func(o *samplerOptions) {
 		o.updaters = updaters
 	}
@@ -111,6 +113,15 @@ func (o *samplerOptions) applyOptionsAndDefaults(opts ...SamplerOption) *sampler
 	}
 	if o.samplingRefreshInterval <= 0 {
 		o.samplingRefreshInterval = defaultSamplingRefreshInterval
+	}
+	if o.samplingFetcher == nil {
+		o.samplingFetcher = &httpSamplingStrategyFetcher{
+			serverURL: o.samplingServerURL,
+			logger:    o.logger,
+		}
+	}
+	if o.samplingParser == nil {
+		o.samplingParser = new(samplingStrategyParser)
 	}
 	if o.updaters == nil {
 		o.updaters = []SamplerUpdater{

--- a/sampler_remote_options.go
+++ b/sampler_remote_options.go
@@ -85,6 +85,20 @@ func (samplerOptions) SamplingRefreshInterval(samplingRefreshInterval time.Durat
 	}
 }
 
+// SamplingStrategyFetcher creates a SamplerOption that initializes sampling strategy fetcher.
+func (samplerOptions) SamplingStrategyFetcher(fetcher SamplingStrategyFetcher) SamplerOption {
+	return func(o *samplerOptions) {
+		o.samplingFetcher = fetcher
+	}
+}
+
+// SamplingStrategyParser creates a SamplerOption that initializes sampling strategy parser.
+func (samplerOptions) SamplingStrategyParser(parser SamplingStrategyParser) SamplerOption {
+	return func(o *samplerOptions) {
+		o.samplingParser = parser
+	}
+}
+
 // Updaters creates a SamplerOption that initializes sampler updaters.
 func (samplerOptions) Updaters(updaters ...SamplerUpdater) SamplerOption {
 	return func(o *samplerOptions) {

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -415,15 +415,14 @@ func TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler(t *t
 	for _, tc := range testCases {
 		testCase := tc // capture loop var
 		t.Run(testCase.caption, func(t *testing.T) {
-			remoteSampler := &RemotelyControlledSampler{
-				samplerOptions: samplerOptions{
-					sampler: testCase.initSampler,
-				},
-				updaters: []SamplerUpdater{
-					new(probabilisticSamplerUpdater),
-					new(rateLimitingSamplerUpdater),
-				},
-			}
+			remoteSampler := NewRemotelyControlledSampler(
+				"test",
+				SamplerOptions.InitialSampler(testCase.initSampler.(Sampler)),
+				SamplerOptions.Updaters([]SamplerUpdater{
+					new(ProbabilisticSamplerUpdater),
+					new(RateLimitingSamplerUpdater),
+				}),
+			)
 			err := remoteSampler.updateSamplerViaUpdaters(testCase.res)
 			if testCase.shouldErr {
 				require.Error(t, err)

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -83,12 +83,12 @@ func TestRemotelyControlledSampler(t *testing.T) {
 
 	agent.AddSamplingStrategy("client app",
 		getSamplingStrategyResponse(sampling.SamplingStrategyType_PROBABILISTIC, testDefaultSamplingProbability))
-	remoteSampler.updateSampler()
+	remoteSampler.UpdateSampler()
 	metricsFactory.AssertCounterMetrics(t, []mTestutils.ExpectedMetric{
 		{Name: "jaeger.tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
 		{Name: "jaeger.tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
 	}...)
-	s1, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
+	s1, ok := remoteSampler.GetSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
 	assert.EqualValues(t, testDefaultSamplingProbability, s1.samplingRate, "Sampler should have been updated")
 
@@ -109,7 +109,7 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	remoteSampler.Close()
 
-	s2, ok := remoteSampler.getSampler().(*ProbabilisticSampler)
+	s2, ok := remoteSampler.GetSampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
 	assert.EqualValues(t, testDefaultSamplingProbability, s2.samplingRate, "Sampler should have been updated from timer")
 
@@ -192,7 +192,7 @@ func TestRemotelyControlledSampler_updateSampler(t *testing.T) {
 			}
 
 			agent.AddSamplingStrategy("client app", res)
-			sampler.updateSampler()
+			sampler.UpdateSampler()
 
 			metricsFactory.AssertCounterMetrics(t,
 				mTestutils.ExpectedMetric{
@@ -227,7 +227,7 @@ func TestRemotelyControlledSampler_updateDefaultRate(t *testing.T) {
 		},
 	}
 	agent.AddSamplingStrategy("client app", res)
-	sampler.updateSampler()
+	sampler.UpdateSampler()
 
 	// Check what rate we get for a specific operation
 	decision := sampler.OnCreateSpan(makeSpan(0, testOperationName))
@@ -236,7 +236,7 @@ func TestRemotelyControlledSampler_updateDefaultRate(t *testing.T) {
 
 	// Change the default and update
 	res.OperationSampling.DefaultSamplingProbability = 0.1
-	sampler.updateSampler()
+	sampler.UpdateSampler()
 
 	// Check sampling rate has changed
 	decision = sampler.OnCreateSpan(makeSpan(0, testOperationName))
@@ -250,7 +250,7 @@ func TestRemotelyControlledSampler_updateDefaultRate(t *testing.T) {
 			SamplingRate: 0.2,
 		},
 	}}
-	sampler.updateSampler()
+	sampler.UpdateSampler()
 
 	// Check we get the requested rate
 	decision = sampler.OnCreateSpan(makeSpan(0, testOperationName))
@@ -259,7 +259,7 @@ func TestRemotelyControlledSampler_updateDefaultRate(t *testing.T) {
 
 	// Now remove the operation-specific rate
 	res.OperationSampling.PerOperationStrategies = nil
-	sampler.updateSampler()
+	sampler.UpdateSampler()
 
 	// Check we get the default rate
 	assert.True(t, decision.Sample)
@@ -280,7 +280,7 @@ func TestSamplerQueryError(t *testing.T) {
 
 	sampler.Close() // stop timer-based updates, we want to call them manually
 
-	sampler.updateSampler()
+	sampler.UpdateSampler()
 	assert.Equal(t, initSampler, sampler.sampler, "Sampler should not have been updated due to query error")
 
 	metricsFactory.AssertCounterMetrics(t,
@@ -312,7 +312,7 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 
 	agent.AddSamplingStrategy("client app",
 		getSamplingStrategyResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.5))
-	remoteSampler.updateSampler()
+	remoteSampler.UpdateSampler()
 
 	// Sampler should have been updated to probabilistic
 	_, ok := remoteSampler.sampler.(*ProbabilisticSampler)
@@ -323,7 +323,7 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 
 	agent.AddSamplingStrategy("client app",
 		getSamplingStrategyResponse(sampling.SamplingStrategyType_RATE_LIMITING, 1))
-	remoteSampler.updateSampler()
+	remoteSampler.UpdateSampler()
 
 	// Sampler should have been updated to ratelimiting
 	_, ok = remoteSampler.sampler.(*RateLimitingSampler)
@@ -334,7 +334,7 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 
 	// Update existing adaptive sampler
 	agent.AddSamplingStrategy("client app", &sampling.SamplingStrategyResponse{OperationSampling: strategies})
-	remoteSampler.updateSampler()
+	remoteSampler.UpdateSampler()
 
 	metricsFactory.AssertCounterMetrics(t,
 		mTestutils.ExpectedMetric{Name: "jaeger.tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 3},
@@ -469,7 +469,7 @@ func TestRemotelyControlledSampler_printErrorForBrokenUpstream(t *testing.T) {
 		SamplerOptions.Logger(logger),
 	)
 	sampler.Close() // stop timer-based updates, we want to call them manually
-	sampler.updateSampler()
+	sampler.UpdateSampler()
 
 	assert.Contains(t, logger.String(), "failed to fetch sampling strategy:")
 }

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -415,8 +415,16 @@ func TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler(t *t
 	for _, tc := range testCases {
 		testCase := tc // capture loop var
 		t.Run(testCase.caption, func(t *testing.T) {
-			remoteSampler := &RemotelyControlledSampler{samplerOptions: samplerOptions{sampler: testCase.initSampler}}
-			err := remoteSampler.updateRateLimitingOrProbabilisticSampler(testCase.res)
+			remoteSampler := &RemotelyControlledSampler{
+				samplerOptions: samplerOptions{
+					sampler: testCase.initSampler,
+				},
+				updaters: []SamplerUpdater{
+					new(probabilisticSamplerUpdater),
+					new(rateLimitingSamplerUpdater),
+				},
+			}
+			err := remoteSampler.updateSamplerViaUpdaters(testCase.res)
 			if testCase.shouldErr {
 				require.Error(t, err)
 				return

--- a/testutils/mock_agent.go
+++ b/testutils/mock_agent.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/uber/jaeger-client-go/thrift-gen/agent"
 	"github.com/uber/jaeger-client-go/thrift-gen/jaeger"
-	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
 	"github.com/uber/jaeger-client-go/thrift-gen/zipkincore"
 	"github.com/uber/jaeger-client-go/utils"
 )
@@ -137,7 +136,7 @@ func (s *MockAgent) IsServing() bool {
 }
 
 // AddSamplingStrategy registers a sampling strategy for a service
-func (s *MockAgent) AddSamplingStrategy(service string, strategy *sampling.SamplingStrategyResponse) {
+func (s *MockAgent) AddSamplingStrategy(service string, strategy interface{}) {
 	s.samplingMgr.AddSamplingStrategy(service, strategy)
 }
 

--- a/testutils/sampling_manager.go
+++ b/testutils/sampling_manager.go
@@ -22,17 +22,17 @@ import (
 
 func newSamplingManager() *samplingManager {
 	return &samplingManager{
-		sampling: make(map[string]*sampling.SamplingStrategyResponse),
+		sampling: make(map[string]interface{}),
 	}
 }
 
 type samplingManager struct {
-	sampling map[string]*sampling.SamplingStrategyResponse
+	sampling map[string]interface{}
 	mutex    sync.Mutex
 }
 
 // GetSamplingStrategy implements handler method of sampling.SamplingManager
-func (s *samplingManager) GetSamplingStrategy(serviceName string) (*sampling.SamplingStrategyResponse, error) {
+func (s *samplingManager) GetSamplingStrategy(serviceName string) (interface{}, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if strategy, ok := s.sampling[serviceName]; ok {
@@ -46,7 +46,7 @@ func (s *samplingManager) GetSamplingStrategy(serviceName string) (*sampling.Sam
 }
 
 // AddSamplingStrategy registers a sampling strategy for a service
-func (s *samplingManager) AddSamplingStrategy(service string, strategy *sampling.SamplingStrategyResponse) {
+func (s *samplingManager) AddSamplingStrategy(service string, strategy interface{}) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.sampling[service] = strategy


### PR DESCRIPTION
Part of #449, to allow parsing custom/extended strategy response from the agent

- delegate updating individual samplers to replaceable SamplerUpdater(s)
- introduce replaceable sampling strategy Fetcher and Parser
- add unit tests simulating custom sampler