### PR TITLE
Do not apply adaptive sampler to child spans

### DIFF
--- a/propagation_test.go
+++ b/propagation_test.go
@@ -101,7 +101,6 @@ func TestSpanPropagator(t *testing.T) {
 			t.Fatalf("%d: ParentID %d does not match expectation %d", i, a, e)
 		} else {
 			// Prepare for comparison.
-			// sp.context.spanID, sp.context.parentID = exp.context.SpanID(), 0
 			sp.duration, sp.startTime = exp.duration, exp.startTime
 		}
 		assert.Equal(t, exp.context.traceID, sp.context.traceID, formatName)

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -101,10 +101,12 @@ func TestSpanPropagator(t *testing.T) {
 			t.Fatalf("%d: ParentID %d does not match expectation %d", i, a, e)
 		} else {
 			// Prepare for comparison.
-			sp.context.spanID, sp.context.parentID = exp.context.SpanID(), 0
+			// sp.context.spanID, sp.context.parentID = exp.context.SpanID(), 0
 			sp.duration, sp.startTime = exp.duration, exp.startTime
 		}
-		assert.Equal(t, exp.context, sp.context, formatName)
+		assert.Equal(t, exp.context.traceID, sp.context.traceID, formatName)
+		assert.Equal(t, exp.context.Flags(), sp.context.Flags(), formatName)
+		assert.Equal(t, exp.context.baggage, sp.context.baggage, formatName)
 		assert.Equal(t, "span.kind", sp.tags[0].key)
 		assert.Equal(t, expTags, sp.tags[1:] /*skip span.kind tag*/, formatName)
 		assert.Empty(t, sp.logs, formatName)

--- a/sampler.go
+++ b/sampler.go
@@ -361,12 +361,14 @@ func (s *AdaptiveSampler) IsSampled(id TraceID, operation string) (bool, []Tag) 
 	return false, nil
 }
 
-func (s *AdaptiveSampler) trySampling(span *Span, operationName string) (sampled bool, tags []Tag) {
+func (s *AdaptiveSampler) trySampling(span *Span, operationName string) (bool, []Tag) {
 	samplerV1 := s.getSamplerForOperation(operationName)
+	var sampled bool
+	var tags []Tag
 	if span.context.samplingState.isLocalRootSpan(span.context.spanID) {
 		sampled, tags = samplerV1.IsSampled(span.context.TraceID(), operationName)
 	}
-	return
+	return sampled, tags
 }
 
 // OnCreateSpan implements OnCreateSpan of SamplerV2.

--- a/sampler.go
+++ b/sampler.go
@@ -365,14 +365,22 @@ func (s *AdaptiveSampler) IsSampled(id TraceID, operation string) (bool, []Tag) 
 func (s *AdaptiveSampler) OnCreateSpan(span *Span) SamplingDecision {
 	operationName := span.OperationName()
 	samplerV1 := s.getSamplerForOperation(operationName)
-	sampled, tags := samplerV1.IsSampled(span.context.TraceID(), operationName)
+	sampled := false
+	var tags []Tag
+	if span.context.samplingState.isLocalRootSpan(span.context.spanID) {
+		sampled, tags = samplerV1.IsSampled(span.context.TraceID(), operationName)
+	}
 	return SamplingDecision{Sample: sampled, Retryable: true, Tags: tags}
 }
 
 // OnSetOperationName implements OnSetOperationName of SamplerV2.
 func (s *AdaptiveSampler) OnSetOperationName(span *Span, operationName string) SamplingDecision {
 	samplerV1 := s.getSamplerForOperation(operationName)
-	sampled, tags := samplerV1.IsSampled(span.context.TraceID(), operationName)
+	sampled := false
+	var tags []Tag
+	if span.context.samplingState.isLocalRootSpan(span.context.spanID) {
+		sampled, tags = samplerV1.IsSampled(span.context.TraceID(), operationName)
+	}
 	return SamplingDecision{Sample: sampled, Retryable: false, Tags: tags}
 }
 

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/span_context.go
+++ b/span_context.go
@@ -84,9 +84,16 @@ type samplingState struct {
 	// like SetOperationName / SetTag, and the spans will remain writable.
 	final atomic.Bool
 
+	// localRootSpan stores the SpanID of the first span created in this process for a given trace.
+	localRootSpan SpanID
+
 	// extendedState allows samplers to keep intermediate state.
 	// The keys and values in this map are completely opaque: interface{} -> interface{}.
 	extendedState sync.Map
+}
+
+func (s *samplingState) isLocalRootSpan(id SpanID) bool {
+	return id == s.localRootSpan
 }
 
 func (s *samplingState) setFlag(newFlag int32) {


### PR DESCRIPTION
* Similar to https://github.com/jaegertracing/jaeger-client-node/pull/410
* Part of #449 

## Which problem is this PR solving?

Per-operation adaptive sampling should only apply to service endpoints, not to operation names of the inner/children spans. Otherwise it's a problem for adaptive sampling backend that only records operations from the root spans, meaning all child operations are getting the default probability, which may be higher than the calculated probabilities.

## Short description of the changes

- Add a test that demonstrates the problem.
- Change per-operation sampler to only allow sampling "local root spans", which is equivalent to the actual root span of the trace because spans with remote parent are finalized right away.
