### PR TITLE
Make delayed sampling optional

### DIFF
--- a/crossdock/client/client_test.go
+++ b/crossdock/client/client_test.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/crossdock/crossdock-go"
@@ -89,8 +90,11 @@ func TestCrossdock(t *testing.T) {
 			for k, v := range entry {
 				entryArgs.Set(k, v)
 			}
-			// test via real HTTP call
-			crossdock.Call(t, c.URL(), bb.name, entryArgs)
+			name := strings.ReplaceAll(entryArgs.Encode(), "&", "/")
+			t.Run(name, func(t *testing.T) {
+				// test via real HTTP call
+				crossdock.Call(t, c.URL(), bb.name, entryArgs)
+			})
 		}
 	}
 }

--- a/sampler.go
+++ b/sampler.go
@@ -335,7 +335,16 @@ type PerOperationSampler struct {
 	operationNameLateBinding bool
 }
 
-// PerOperationSamplerParams defines parameters when creating an adaptive sampler.
+// NewAdaptiveSampler returns a new PerOperationSampler.
+// Deprecated: please use NewPerOperationSampler.
+func NewAdaptiveSampler(strategies *sampling.PerOperationSamplingStrategies, maxOperations int) (*PerOperationSampler, error) {
+	return NewPerOperationSampler(PerOperationSamplerParams{
+		MaxOperations: maxOperations,
+		Strategies:    strategies,
+	}), nil
+}
+
+// PerOperationSamplerParams defines parameters when creating PerOperationSampler.
 type PerOperationSamplerParams struct {
 	// Max number of operations that will be tracked. Other operations will be given default strategy.
 	MaxOperations int
@@ -350,15 +359,6 @@ type PerOperationSamplerParams struct {
 
 	// Initial configuration of the sampling strategies (usually retrieved from the backend by Remote Sampler).
 	Strategies *sampling.PerOperationSamplingStrategies
-}
-
-// NewAdaptiveSampler returns a new PerOperationSampler.
-// Deprecated: please use NewPerOperationSampler.
-func NewAdaptiveSampler(strategies *sampling.PerOperationSamplingStrategies, maxOperations int) (*PerOperationSampler, error) {
-	return NewPerOperationSampler(PerOperationSamplerParams{
-		MaxOperations: maxOperations,
-		Strategies:    strategies,
-	}), nil
 }
 
 // NewPerOperationSampler returns a new PerOperationSampler.

--- a/sampler.go
+++ b/sampler.go
@@ -42,7 +42,7 @@ type Sampler interface {
 
 	// Equal checks if the `other` sampler is functionally equivalent
 	// to this sampler.
-	// TODO (breaking change) remove this function. See AdaptiveSampler.Equals for explanation.
+	// TODO (breaking change) remove this function. See PerOperationSampler.Equals for explanation.
 	Equal(other Sampler) bool
 }
 
@@ -305,7 +305,7 @@ func (s *GuaranteedThroughputProbabilisticSampler) Close() {
 
 // Equal implements Equal() of Sampler.
 func (s *GuaranteedThroughputProbabilisticSampler) Equal(other Sampler) bool {
-	// NB The Equal() function is expensive and will be removed. See AdaptiveSampler.Equal() for
+	// NB The Equal() function is expensive and will be removed. See PerOperationSampler.Equal() for
 	// more information.
 	return false
 }
@@ -321,9 +321,9 @@ func (s *GuaranteedThroughputProbabilisticSampler) update(lowerBound, samplingRa
 
 // -----------------------
 
-// AdaptiveSampler is a delegating sampler that applies GuaranteedThroughputProbabilisticSampler
+// PerOperationSampler is a delegating sampler that applies GuaranteedThroughputProbabilisticSampler
 // on a per-operation basis.
-type AdaptiveSampler struct {
+type PerOperationSampler struct {
 	sync.RWMutex
 
 	samplers       map[string]*GuaranteedThroughputProbabilisticSampler
@@ -331,12 +331,12 @@ type AdaptiveSampler struct {
 	lowerBound     float64
 	maxOperations  int
 
-	// see description in AdaptiveSamplerParams
+	// see description in PerOperationSamplerParams
 	operationNameLateBinding bool
 }
 
-// AdaptiveSamplerParams defines parameters when creating an adaptive sampler.
-type AdaptiveSamplerParams struct {
+// PerOperationSamplerParams defines parameters when creating an adaptive sampler.
+type PerOperationSamplerParams struct {
 	// Max number of operations that will be tracked. Other operations will be given default strategy.
 	MaxOperations int
 
@@ -352,17 +352,17 @@ type AdaptiveSamplerParams struct {
 	Strategies *sampling.PerOperationSamplingStrategies
 }
 
-// NewAdaptiveSampler returns a new AdaptiveSampler.
-// TODO (breaking change) remove error from return value
-func NewAdaptiveSampler(strategies *sampling.PerOperationSamplingStrategies, maxOperations int) (*AdaptiveSampler, error) {
-	return NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+// NewAdaptiveSampler returns a new PerOperationSampler.
+// Deprecated: please use NewPerOperationSampler.
+func NewAdaptiveSampler(strategies *sampling.PerOperationSamplingStrategies, maxOperations int) (*PerOperationSampler, error) {
+	return NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: maxOperations,
 		Strategies:    strategies,
 	}), nil
 }
 
-// NewAdaptiveSamplerWithParams returns a new AdaptiveSampler.
-func NewAdaptiveSamplerWithParams(params AdaptiveSamplerParams) *AdaptiveSampler {
+// NewPerOperationSampler returns a new PerOperationSampler.
+func NewPerOperationSampler(params PerOperationSamplerParams) *PerOperationSampler {
 	samplers := make(map[string]*GuaranteedThroughputProbabilisticSampler)
 	for _, strategy := range params.Strategies.PerOperationStrategies {
 		sampler := newGuaranteedThroughputProbabilisticSampler(
@@ -371,7 +371,7 @@ func NewAdaptiveSamplerWithParams(params AdaptiveSamplerParams) *AdaptiveSampler
 		)
 		samplers[strategy.Operation] = sampler
 	}
-	return &AdaptiveSampler{
+	return &PerOperationSampler{
 		samplers:                 samplers,
 		defaultSampler:           newProbabilisticSampler(params.Strategies.DefaultSamplingProbability),
 		lowerBound:               params.Strategies.DefaultLowerBoundTracesPerSecond,
@@ -382,11 +382,11 @@ func NewAdaptiveSamplerWithParams(params AdaptiveSamplerParams) *AdaptiveSampler
 
 // IsSampled is not used and only exists to match Sampler V1 API.
 // TODO (breaking change) remove when upgrading everything to SamplerV2
-func (s *AdaptiveSampler) IsSampled(id TraceID, operation string) (bool, []Tag) {
+func (s *PerOperationSampler) IsSampled(id TraceID, operation string) (bool, []Tag) {
 	return false, nil
 }
 
-func (s *AdaptiveSampler) trySampling(span *Span, operationName string) (bool, []Tag) {
+func (s *PerOperationSampler) trySampling(span *Span, operationName string) (bool, []Tag) {
 	samplerV1 := s.getSamplerForOperation(operationName)
 	var sampled bool
 	var tags []Tag
@@ -397,28 +397,28 @@ func (s *AdaptiveSampler) trySampling(span *Span, operationName string) (bool, [
 }
 
 // OnCreateSpan implements OnCreateSpan of SamplerV2.
-func (s *AdaptiveSampler) OnCreateSpan(span *Span) SamplingDecision {
+func (s *PerOperationSampler) OnCreateSpan(span *Span) SamplingDecision {
 	sampled, tags := s.trySampling(span, span.OperationName())
 	return SamplingDecision{Sample: sampled, Retryable: s.operationNameLateBinding, Tags: tags}
 }
 
 // OnSetOperationName implements OnSetOperationName of SamplerV2.
-func (s *AdaptiveSampler) OnSetOperationName(span *Span, operationName string) SamplingDecision {
+func (s *PerOperationSampler) OnSetOperationName(span *Span, operationName string) SamplingDecision {
 	sampled, tags := s.trySampling(span, operationName)
 	return SamplingDecision{Sample: sampled, Retryable: false, Tags: tags}
 }
 
 // OnSetTag implements OnSetTag of SamplerV2.
-func (s *AdaptiveSampler) OnSetTag(span *Span, key string, value interface{}) SamplingDecision {
+func (s *PerOperationSampler) OnSetTag(span *Span, key string, value interface{}) SamplingDecision {
 	return SamplingDecision{Sample: false, Retryable: true}
 }
 
 // OnFinishSpan implements OnFinishSpan of SamplerV2.
-func (s *AdaptiveSampler) OnFinishSpan(span *Span) SamplingDecision {
+func (s *PerOperationSampler) OnFinishSpan(span *Span) SamplingDecision {
 	return SamplingDecision{Sample: false, Retryable: true}
 }
 
-func (s *AdaptiveSampler) getSamplerForOperation(operation string) Sampler {
+func (s *PerOperationSampler) getSamplerForOperation(operation string) Sampler {
 	s.RLock()
 	sampler, ok := s.samplers[operation]
 	if ok {
@@ -444,7 +444,7 @@ func (s *AdaptiveSampler) getSamplerForOperation(operation string) Sampler {
 }
 
 // Close invokes Close on all underlying samplers.
-func (s *AdaptiveSampler) Close() {
+func (s *PerOperationSampler) Close() {
 	s.Lock()
 	defer s.Unlock()
 	for _, sampler := range s.samplers {
@@ -455,16 +455,16 @@ func (s *AdaptiveSampler) Close() {
 
 // Equal is not used.
 // TODO (breaking change) remove this in the future
-func (s *AdaptiveSampler) Equal(other Sampler) bool {
-	// NB The Equal() function is overly expensive for AdaptiveSampler since it's composed of multiple
+func (s *PerOperationSampler) Equal(other Sampler) bool {
+	// NB The Equal() function is overly expensive for PerOperationSampler since it's composed of multiple
 	// samplers which all need to be initialized before this function can be called for a comparison.
-	// Therefore, AdaptiveSampler uses the update() function to only alter the samplers that need
+	// Therefore, PerOperationSampler uses the update() function to only alter the samplers that need
 	// changing. Hence this function always returns false so that the update function can be called.
 	// Once the Equal() function is removed from the Sampler API, this will no longer be needed.
 	return false
 }
 
-func (s *AdaptiveSampler) update(strategies *sampling.PerOperationSamplingStrategies) {
+func (s *PerOperationSampler) update(strategies *sampling.PerOperationSamplingStrategies) {
 	s.Lock()
 	defer s.Unlock()
 	newSamplers := map[string]*GuaranteedThroughputProbabilisticSampler{}

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -127,7 +127,7 @@ func (s *RemotelyControlledSampler) Close() {
 
 // Equal implements Equal() of Sampler.
 func (s *RemotelyControlledSampler) Equal(other Sampler) bool {
-	// NB The Equal() function is expensive and will be removed. See AdaptiveSampler.Equal() for
+	// NB The Equal() function is expensive and will be removed. See PerOperationSampler.Equal() for
 	// more information.
 	return false
 }
@@ -271,11 +271,11 @@ func (u *AdaptiveSamplerUpdater) Update(sampler SamplerV2, strategy interface{})
 	var _ response = new(sampling.SamplingStrategyResponse) // sanity signature check
 	if p, ok := strategy.(response); ok {
 		if operations := p.GetOperationSampling(); operations != nil {
-			if as, ok := sampler.(*AdaptiveSampler); ok {
+			if as, ok := sampler.(*PerOperationSampler); ok {
 				as.update(operations)
 				return as, nil
 			}
-			return NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+			return NewPerOperationSampler(PerOperationSamplerParams{
 				MaxOperations:            u.MaxOperations,
 				OperationNameLateBinding: u.OperationNameLateBinding,
 				Strategies:               operations,

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -259,7 +259,8 @@ func (u *RateLimitingSamplerUpdater) Update(sampler SamplerV2, strategy interfac
 
 // AdaptiveSamplerUpdater is used by RemotelyControlledSampler to parse sampling configuration.
 type AdaptiveSamplerUpdater struct {
-	MaxOperations int // required
+	MaxOperations            int // required
+	OperationNameLateBinding bool
 }
 
 // Update implements Update of SamplerUpdater.
@@ -274,7 +275,11 @@ func (u *AdaptiveSamplerUpdater) Update(sampler SamplerV2, strategy interface{})
 				as.update(operations)
 				return as, nil
 			}
-			return newAdaptiveSampler(operations, u.MaxOperations), nil
+			return NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+				MaxOperations:            u.MaxOperations,
+				OperationNameLateBinding: u.OperationNameLateBinding,
+				Strategies:               operations,
+			}), nil
 		}
 	}
 	return nil, nil

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -303,9 +303,10 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 		DefaultSamplingProbability:       testDefaultSamplingProbability,
 		DefaultLowerBoundTracesPerSecond: 1.0,
 	}
-
-	adaptiveSampler, err := NewAdaptiveSampler(strategies, testDefaultMaxOperations)
-	require.NoError(t, err)
+	adaptiveSampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+		MaxOperations: testDefaultMaxOperations,
+		Strategies:    strategies,
+	})
 
 	// Overwrite the sampler with an adaptive sampler
 	remoteSampler.sampler = adaptiveSampler

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -200,7 +200,7 @@ func TestRemotelyControlledSampler_updateSampler(t *testing.T) {
 				},
 			)
 
-			s, ok := sampler.sampler.(*AdaptiveSampler)
+			s, ok := sampler.sampler.(*PerOperationSampler)
 			assert.True(t, ok)
 			assert.NotEqual(t, initSampler, sampler.sampler, "Sampler should have been updated")
 			assert.Equal(t, test.expectedDefaultProbability, s.defaultSampler.SamplingRate())
@@ -303,7 +303,7 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 		DefaultSamplingProbability:       testDefaultSamplingProbability,
 		DefaultLowerBoundTracesPerSecond: 1.0,
 	}
-	adaptiveSampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	adaptiveSampler := NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
 	})

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -162,7 +162,7 @@ func TestAdaptiveSampler(t *testing.T) {
 		PerOperationStrategies:           samplingRates,
 	}
 
-	sampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	sampler := NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
 	})
@@ -197,14 +197,14 @@ func TestAdaptiveSamplerErrors(t *testing.T) {
 		},
 	}
 
-	sampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	sampler := NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
 	})
 	assert.Equal(t, 0.0, sampler.samplers[testOperationName].samplingRate)
 
 	strategies.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate = 1.1
-	sampler = NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	sampler = NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
 	})
@@ -226,7 +226,7 @@ func TestAdaptiveSamplerUpdate(t *testing.T) {
 		PerOperationStrategies:           samplingRates,
 	}
 
-	sampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	sampler := NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
 	})
@@ -274,7 +274,7 @@ func TestMaxOperations(t *testing.T) {
 		PerOperationStrategies:           samplingRates,
 	}
 
-	sampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	sampler := NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: 1,
 		Strategies:    strategies,
 	})
@@ -299,7 +299,7 @@ func TestAdaptiveSamplerDoesNotApplyToChildrenSpans(t *testing.T) {
 			},
 		},
 	}
-	sampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	sampler := NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations:            1,
 		OperationNameLateBinding: true, // these tests rely on late binding
 		Strategies:               strategies,
@@ -334,7 +334,7 @@ func TestAdaptiveSampler_lockRaceCondition(t *testing.T) {
 	remoteSampler.Close() // stop timer-based updates, we want to call them manually
 
 	numOperations := 1000
-	adaptiveSampler := NewAdaptiveSamplerWithParams(AdaptiveSamplerParams{
+	adaptiveSampler := NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: 2000,
 		Strategies: &sampling.PerOperationSamplingStrategies{
 			DefaultSamplingProbability: 1,

--- a/sampler_v2_test.go
+++ b/sampler_v2_test.go
@@ -29,7 +29,7 @@ var (
 	_ SamplerV2 = new(ConstSampler)
 	_ SamplerV2 = new(ProbabilisticSampler)
 	_ SamplerV2 = new(RateLimitingSampler)
-	_ SamplerV2 = new(AdaptiveSampler)
+	_ SamplerV2 = new(PerOperationSampler)
 	// Note: GuaranteedThroughputProbabilisticSampler is currently not V2
 
 	_ Sampler   = new(retryableTestSampler)

--- a/scripts/bench.Makefile
+++ b/scripts/bench.Makefile
@@ -1,0 +1,10 @@
+# A small helper Makefile to build the benchmark binary so that it can be run on other machines.
+#
+# The binary can be run with
+#     $ ./benchmark.bin -test.bench=BenchmarkTracer -test.run=BenchmarkTracer
+
+build:
+	go test -c -o=benchmark.bin .
+
+build-linux:
+	CGO_ENABLED=0 GOOS=linux go test -c -o=benchmark.bin .

--- a/tracer_bench_test.go
+++ b/tracer_bench_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+type benchSampler struct {
+	name    string
+	sampler Sampler
+}
+
+func (b benchSampler) String() string {
+	return b.name
+}
+
+func benchAdaptiveSampler(lateBinding bool, prob float64) Sampler {
+	ops := makeOps(5)
+	samplingRates := make([]*sampling.OperationSamplingStrategy, 5)
+	for i, op := range ops {
+		samplingRates[i] = &sampling.OperationSamplingStrategy{
+			Operation:             op,
+			ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{SamplingRate: prob},
+		}
+	}
+	strategies := &sampling.PerOperationSamplingStrategies{
+		DefaultSamplingProbability:       prob,
+		DefaultLowerBoundTracesPerSecond: 0,
+		PerOperationStrategies:           samplingRates,
+	}
+	return NewPerOperationSampler(PerOperationSamplerParams{
+		MaxOperations:            7,
+		OperationNameLateBinding: lateBinding,
+		Strategies:               strategies,
+	})
+	// Change to below when running on <=2.19
+	//return newAdaptiveSampler(strategies, 7)
+}
+
+func BenchmarkTracer(b *testing.B) {
+	axes := []axis{
+		{
+			name: "sampler",
+			values: []interface{}{
+				benchSampler{name: "NeverSample", sampler: NewConstSampler(false)},
+				benchSampler{name: "AlwaysSample", sampler: NewConstSampler(true)},
+				benchSampler{name: "AdaptiveNeverSampleNoLateBinding", sampler: benchAdaptiveSampler(false, 0)},
+				benchSampler{name: "AdaptiveAlwaysSampleNoLateBinding", sampler: benchAdaptiveSampler(false, 1)},
+				benchSampler{name: "AdaptiveNeverSampleWithLateBinding", sampler: benchAdaptiveSampler(true, 0)},
+				benchSampler{name: "AdaptiveAlwaysSampleWithLateBinding", sampler: benchAdaptiveSampler(true, 1)},
+			},
+		},
+		// adding remote sampler on top of others did not show significant impact, keeping it off for now.
+		{name: "remoteSampler", values: []interface{}{false}},
+		{name: "children", values: []interface{}{false, true}},
+		// tags and ops dimensions did not show significant impact, so keeping to one value only for now.
+		{name: "tags", values: []interface{}{5}},
+		{name: "ops", values: []interface{}{10}},
+	}
+	for _, entry := range combinations(axes) {
+		b.Run(entry.encode(axes)+"cpus", func(b *testing.B) {
+			sampler := entry["sampler"].(benchSampler).sampler
+			if entry["remoteSampler"].(bool) {
+				sampler = NewRemotelyControlledSampler("service",
+					SamplerOptions.InitialSampler(sampler),
+					SamplerOptions.SamplingRefreshInterval(time.Minute),
+				)
+			}
+			options := benchOptions{
+				tags:     entry["tags"].(int),
+				ops:      entry["ops"].(int),
+				sampler:  sampler,
+				children: entry["children"].(bool),
+			}
+			benchmarkTracer(b, options)
+		})
+	}
+}
+
+type benchOptions struct {
+	tags     int
+	ops      int
+	sampler  Sampler
+	children bool
+}
+
+func benchmarkTracer(b *testing.B, options benchOptions) {
+	tags := makeStrings("tag", options.tags)
+	ops := makeOps(options.ops)
+
+	sampler := options.sampler
+	tracer, closer := NewTracer("service", sampler, NewNullReporter())
+	defer closer.Close()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		var parent opentracing.SpanContext
+		var op int
+		for pb.Next() {
+			span := tracer.StartSpan(ops[op], opentracing.ChildOf(parent))
+			for i := range tags {
+				span.SetTag(tags[i], tags[i])
+			}
+			if options.children {
+				parent = span.Context()
+			}
+			span.Finish()
+			op = (op + 1) % len(ops)
+		}
+	})
+}
+
+func makeOps(num int) []string {
+	return makeStrings("span", num)
+}
+
+func makeStrings(prefix string, num int) []string {
+	values := make([]string, num)
+	for i := 0; i < num; i++ {
+		values[i] = fmt.Sprintf("%s%02d", prefix, i)
+	}
+	return values
+}
+
+// combinations takes a list axes and their values and
+// returns a collection of entries which contain all combinations of each axis
+// value with every other axis' values.
+func combinations(axes []axis) []permutation {
+	if len(axes) == 0 {
+		return nil
+	}
+
+	if len(axes) == 1 {
+		return axes[0].entries()
+	}
+
+	var entries []permutation
+	// combos := combinations(axes[1:])
+	last := len(axes) - 1
+	combos := combinations(axes[:last])
+	for _, remaining := range combos {
+		for _, entry := range axes[last].entries() {
+			for k, v := range remaining {
+				entry[k] = v
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}
+
+type axis struct {
+	name   string
+	values []interface{}
+}
+
+func (x axis) entries() []permutation {
+	items := make([]permutation, len(x.values))
+	for i, value := range x.values {
+		items[i] = permutation{x.name: value}
+	}
+	return items
+}
+
+type permutation map[string]interface{}
+
+// encode converts a permutation into a string "k=v/k=v/...".
+// The axes argument is used to provide a definitive order of keys.
+func (p permutation) encode(axes []axis) string {
+	name := ""
+	for _, axis := range axes {
+		k := axis.name
+		v := p[k]
+		name = name + fmt.Sprintf("%s=%v", k, v) + "/"
+	}
+	return name
+}


### PR DESCRIPTION
Part of #449.

Recent changes to `adaptiveSampler` introduced a potential performance degradation, addressed here via a new opt-in option `OperationNameLateBinding`:

> Opt-in feature for applications that require late binding of span name via explicit call to `SetOperationName`. When this feature is enabled, the sampler will return `retryable=true` from `OnCreateSpan()`, thus leaving the sampling decision as non-final (and the span as writeable). This may lead to degraded performance in applications that always provide the correct span name on trace creation.

The PR also renames `AdaptiveSampler` to `PerOperationSampler`, to better reflect its purpose. The public name AdaptiveSampler has not been released yet, the previous release had it private `adaptiveSampler`.

## Benchmarks

Legend:
  * `children=false` means that every span starts a new trace (and getting sampled)
  * `children=true` means that most spans are created as a child of the previous span
  * Standalone `NeverSample/AlwaysSample` means using Const sampler
  * Adaptive(NeverSample|AlwaysSample) means using 100%/0% probability and 0 lower bound rate

### Before
```
AdaptiveNeverSampleNoLateBinding/children=false/cpus-32         	  262648	      3886 ns/op
AdaptiveNeverSampleNoLateBinding/children=true/cpus-32          	 2388068	       485 ns/op
AdaptiveAlwaysSampleNoLateBinding/children=false/cpus-32        	  486133	      4813 ns/op
AdaptiveAlwaysSampleNoLateBinding/children=true/cpus-32         	 1451222	       802 ns/op
AdaptiveNeverSampleWithLateBinding/children=false/cpus-32       	  453198	      3879 ns/op
AdaptiveNeverSampleWithLateBinding/children=true/cpus-32        	 2221748	       489 ns/op
AdaptiveAlwaysSampleWithLateBinding/children=false/cpus-32      	  343279	      4946 ns/op
AdaptiveAlwaysSampleWithLateBinding/children=true/cpus-32       	 1348515	       827 ns/op
```

### After
```
NeverSample/children=false/cpus-32         	 3243393	       408 ns/op
NeverSample/children=true/cpus-32          	 2363767	       500 ns/op
AlwaysSample/children=false/cpus-32        	 1700967	       748 ns/op
AlwaysSample/children=true/cpus-32         	 1424816	       811 ns/op
AdaptiveNeverSampleNoLateBinding/children=false/cpus-32         	  561810	      2877 ns/op
AdaptiveNeverSampleNoLateBinding/children=true/cpus-32          	 2294772	       507 ns/op
AdaptiveAlwaysSampleNoLateBinding/children=false/cpus-32        	  404061	      3842 ns/op
AdaptiveAlwaysSampleNoLateBinding/children=true/cpus-32         	 1350417	       832 ns/op
AdaptiveNeverSampleWithLateBinding/children=false/cpus-32       	  455553	      4285 ns/op
AdaptiveNeverSampleWithLateBinding/children=true/cpus-32        	  260630	      3870 ns/op
AdaptiveAlwaysSampleWithLateBinding/children=false/cpus-32      	  265951	      4425 ns/op
AdaptiveAlwaysSampleWithLateBinding/children=true/cpus-32       	  255801	      4293 ns/op
```