### PR TITLE
Expose Sampler on Tracer and accept sampler options via Configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,9 @@ type SamplerConfig struct {
 	// jaeger-agent for the appropriate sampling strategy.
 	// Can be set by exporting an environment variable named JAEGER_SAMPLER_REFRESH_INTERVAL
 	SamplingRefreshInterval time.Duration `yaml:"samplingRefreshInterval"`
+
+	// Options can be used to programmatically pass additional options to the Remote sampler.
+	Options []jaeger.SamplerOption
 }
 
 // ReporterConfig configures the reporter. All fields are optional.
@@ -357,6 +360,7 @@ func (sc *SamplerConfig) NewSampler(
 		if sc.SamplingRefreshInterval != 0 {
 			options = append(options, jaeger.SamplerOptions.SamplingRefreshInterval(sc.SamplingRefreshInterval))
 		}
+		options = append(options, sc.Options...)
 		return jaeger.NewRemotelyControlledSampler(serviceName, options...), nil
 	}
 	return nil, fmt.Errorf("Unknown sampler type %v", sc.Type)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,7 +175,7 @@ func TestSamplerConfigOptions(t *testing.T) {
 	sampler, err := cfg.NewSampler("service", jaeger.NewNullMetrics())
 	require.NoError(t, err)
 	defer sampler.Close()
-	assert.Same(t, initSampler, sampler.(*jaeger.RemotelyControlledSampler).GetSampler())
+	assert.Same(t, initSampler, sampler.(*jaeger.RemotelyControlledSampler).Sampler())
 }
 
 func TestReporter(t *testing.T) {
@@ -531,7 +531,7 @@ func TestInitGlobalTracer(t *testing.T) {
 		{
 			cfg: Configuration{
 				Sampler: &SamplerConfig{
-					Type: "remote",
+					Type:                    "remote",
 					SamplingRefreshInterval: 1,
 				},
 			},

--- a/experimental/sampler_custom_updater_test.go
+++ b/experimental/sampler_custom_updater_test.go
@@ -159,7 +159,7 @@ func TestCustomRemoteSampler(t *testing.T) {
 		// step 1 - probabilistic sampler
 		obj.agent.AddSamplingStrategy("service", &mainStrategy)
 		obj.sampler.UpdateSampler()
-		assertSampler(t, mainSampler, obj.sampler.GetSampler())
+		assertSampler(t, mainSampler, obj.sampler.Sampler())
 
 		// step 2 - combine with tag matching sampler
 		obj.agent.AddSamplingStrategy("service", &customSamplingStrategyResponse{
@@ -167,7 +167,7 @@ func TestCustomRemoteSampler(t *testing.T) {
 			TagMatching:              tagStrategy,
 		})
 		obj.sampler.UpdateSampler()
-		assert.IsType(t, new(PrioritySampler), obj.sampler.GetSampler())
+		assert.IsType(t, new(PrioritySampler), obj.sampler.Sampler())
 		assertSampler(t, neverSampler, obj.updater.mainSampler)
 
 		span := obj.tracer.StartSpan("span")
@@ -178,6 +178,6 @@ func TestCustomRemoteSampler(t *testing.T) {
 		// step 3 - back to probabilistic sampler only
 		obj.agent.AddSamplingStrategy("service", &mainStrategy)
 		obj.sampler.UpdateSampler()
-		assertSampler(t, mainSampler, obj.sampler.GetSampler())
+		assertSampler(t, mainSampler, obj.sampler.Sampler())
 	})
 }

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -150,8 +150,8 @@ func (s *RemotelyControlledSampler) pollControllerWithTicker(ticker *time.Ticker
 	}
 }
 
-// GetSampler returns the currently active sampler.
-func (s *RemotelyControlledSampler) GetSampler() SamplerV2 {
+// Sampler returns the currently active sampler.
+func (s *RemotelyControlledSampler) Sampler() SamplerV2 {
 	s.Lock()
 	defer s.Unlock()
 	return s.sampler

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -88,7 +88,7 @@ func TestRemotelyControlledSampler(t *testing.T) {
 		{Name: "jaeger.tracer.sampler_queries", Tags: map[string]string{"result": "ok"}, Value: 1},
 		{Name: "jaeger.tracer.sampler_updates", Tags: map[string]string{"result": "ok"}, Value: 1},
 	}...)
-	s1, ok := remoteSampler.GetSampler().(*ProbabilisticSampler)
+	s1, ok := remoteSampler.Sampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
 	assert.EqualValues(t, testDefaultSamplingProbability, s1.samplingRate, "Sampler should have been updated")
 
@@ -109,7 +109,7 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	remoteSampler.Close()
 
-	s2, ok := remoteSampler.GetSampler().(*ProbabilisticSampler)
+	s2, ok := remoteSampler.Sampler().(*ProbabilisticSampler)
 	assert.True(t, ok)
 	assert.EqualValues(t, testDefaultSamplingProbability, s2.samplingRate, "Sampler should have been updated from timer")
 

--- a/tracer.go
+++ b/tracer.go
@@ -470,6 +470,11 @@ func (t *Tracer) isDebugAllowed(operation string) bool {
 	return t.debugThrottler.IsAllowed(operation)
 }
 
+// Sampler returns the sampler given to the tracer at creation.
+func (t *Tracer) Sampler() SamplerV2 {
+	return t.sampler
+}
+
 // SelfRef creates an opentracing compliant SpanReference from a jaeger
 // SpanContext. This is a factory function in order to encapsulate jaeger specific
 // types.

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -453,6 +453,14 @@ func TestSetGetTag(t *testing.T) {
 	assert.True(t, tracer.hostIPv4 == 0)
 }
 
+func TestTracerGetSampler(t *testing.T) {
+	sampler := NewRateLimitingSampler(1)
+	tracer, closer := NewTracer("service", sampler, NewNullReporter())
+	defer closer.Close()
+
+	assert.Same(t, sampler, tracer.(*Tracer).Sampler())
+}
+
 type dummyPropagator struct{}
 type dummyCarrier struct {
 	ok bool


### PR DESCRIPTION
## Which problem is this PR solving?

When testing custom configuration mechanism, which in turn uses `config.Configuration` type here, it is not possible to assert what kind of sampler is created, aside from very convoluted way of observing that via side effects.

## Short description of the changes

- Add Sampler() function to the Tracer.
- Rename GetSampler() to Sampler() on the remote sampler, to match the name (non-breaking as the previous name has not been released yet)
- Add Options field to SamplerConfig
