### PR TITLE
Rename package experimental to x

### DIFF
--- a/span_context.go
+++ b/span_context.go
@@ -196,7 +196,7 @@ func (c SpanContext) IsFirehose() bool {
 }
 
 // ExtendedSamplingState returns the custom state object for a given key. If the value for this key does not exist,
-// it is initialized via initValue function. This state can be used by samplers (e.g. experimental.PrioritySampler).
+// it is initialized via initValue function. This state can be used by samplers (e.g. x.PrioritySampler).
 func (c SpanContext) ExtendedSamplingState(key interface{}, initValue func() interface{}) interface{} {
 	return c.samplingState.extendedStateForKey(key, initValue)
 }

--- a/x/doc.go
+++ b/x/doc.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package x contains experimental functionality with no guarantees of stable APIs.
+package x

--- a/x/priority_sampler.go
+++ b/x/priority_sampler.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package experimental
+package x
 
 import (
 	"sync/atomic"

--- a/x/priority_sampler_test.go
+++ b/x/priority_sampler_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package experimental
+package x
 
 import (
 	"testing"

--- a/x/sampler_custom_updater_test.go
+++ b/x/sampler_custom_updater_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package experimental
+package x
 
 import (
 	"encoding/json"

--- a/x/tag_sampler.go
+++ b/x/tag_sampler.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package experimental
+package x
 
 import (
 	"encoding/json"

--- a/x/tag_sampler_test.go
+++ b/x/tag_sampler_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package experimental
+package x
 
 import (
 	"testing"


### PR DESCRIPTION
To follow Go conventions.

Part of #449 