### PR TITLE
Make OperationNameLateBinding externally configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -344,7 +344,7 @@ func (sc *SamplerConfig) NewSampler(
 			return jaeger.NewProbabilisticSampler(sc.Param)
 		}
 		return nil, fmt.Errorf(
-			"Invalid Param for probabilistic sampler: %v. Expecting value between 0 and 1",
+			"invalid Param for probabilistic sampler; expecting value between 0 and 1, received %v",
 			sc.Param,
 		)
 	}
@@ -362,17 +362,14 @@ func (sc *SamplerConfig) NewSampler(
 			jaeger.SamplerOptions.Metrics(metrics),
 			jaeger.SamplerOptions.InitialSampler(initSampler),
 			jaeger.SamplerOptions.SamplingServerURL(sc.SamplingServerURL),
-		}
-		if sc.MaxOperations != 0 {
-			options = append(options, jaeger.SamplerOptions.MaxOperations(sc.MaxOperations))
-		}
-		if sc.SamplingRefreshInterval != 0 {
-			options = append(options, jaeger.SamplerOptions.SamplingRefreshInterval(sc.SamplingRefreshInterval))
+			jaeger.SamplerOptions.MaxOperations(sc.MaxOperations),
+			jaeger.SamplerOptions.OperationNameLateBinding(sc.OperationNameLateBinding),
+			jaeger.SamplerOptions.SamplingRefreshInterval(sc.SamplingRefreshInterval),
 		}
 		options = append(options, sc.Options...)
 		return jaeger.NewRemotelyControlledSampler(serviceName, options...), nil
 	}
-	return nil, fmt.Errorf("Unknown sampler type %v", sc.Type)
+	return nil, fmt.Errorf("unknown sampler type (%s)", sc.Type)
 }
 
 // NewReporter instantiates a new reporter that submits spans to the collector

--- a/config/config.go
+++ b/config/config.go
@@ -76,16 +76,25 @@ type SamplerConfig struct {
 	// Can be set by exporting an environment variable named JAEGER_SAMPLER_MANAGER_HOST_PORT
 	SamplingServerURL string `yaml:"samplingServerURL"`
 
-	// MaxOperations is the maximum number of operations that the sampler
-	// will keep track of. If an operation is not tracked, a default probabilistic
-	// sampler will be used rather than the per operation specific sampler.
-	// Can be set by exporting an environment variable named JAEGER_SAMPLER_MAX_OPERATIONS
-	MaxOperations int `yaml:"maxOperations"`
-
 	// SamplingRefreshInterval controls how often the remotely controlled sampler will poll
 	// jaeger-agent for the appropriate sampling strategy.
 	// Can be set by exporting an environment variable named JAEGER_SAMPLER_REFRESH_INTERVAL
 	SamplingRefreshInterval time.Duration `yaml:"samplingRefreshInterval"`
+
+	// MaxOperations is the maximum number of operations that the PerOperationSampler
+	// will keep track of. If an operation is not tracked, a default probabilistic
+	// sampler will be used rather than the per operation specific sampler.
+	// Can be set by exporting an environment variable named JAEGER_SAMPLER_MAX_OPERATIONS.
+	MaxOperations int `yaml:"maxOperations"`
+
+	// Opt-in feature for applications that require late binding of span name via explicit
+	// call to SetOperationName when using PerOperationSampler. When this feature is enabled,
+	// the sampler will return retryable=true from OnCreateSpan(), thus leaving the sampling
+	// decision as non-final (and the span as writeable). This may lead to degraded performance
+	// in applications that always provide the correct span name on trace creation.
+	//
+	// For backwards compatibility this option is off by default.
+	OperationNameLateBinding bool `yaml:"operationNameLateBinding"`
 
 	// Options can be used to programmatically pass additional options to the Remote sampler.
 	Options []jaeger.SamplerOption

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -504,15 +504,15 @@ func TestDefaultConfig(t *testing.T) {
 
 	cfg.ServiceName = "test"
 	_, closer, err := cfg.NewTracer()
-	defer closeCloser(t, closer)
 	require.NoError(t, err)
+	defer closeCloser(t, closer)
 }
 
 func TestDisabledFlag(t *testing.T) {
 	cfg := Configuration{ServiceName: "test", Disabled: true}
 	_, closer, err := cfg.NewTracer()
-	defer closeCloser(t, closer)
 	require.NoError(t, err)
+	defer closeCloser(t, closer)
 }
 
 func TestNewReporterError(t *testing.T) {
@@ -725,10 +725,11 @@ func TestConfigWithSampler(t *testing.T) {
 
 func TestNewTracer(t *testing.T) {
 	cfg := &Configuration{ServiceName: "my-service"}
-	_, closer, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger))
+	tracer, closer, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger))
+	require.NoError(t, err)
+	require.NotNil(t, tracer)
+	require.NotNil(t, closer)
 	defer closeCloser(t, closer)
-
-	assert.NoError(t, err)
 }
 
 func TestNewTracerWithNoDebugFlagOnForcedSampling(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -67,22 +68,36 @@ func TestNewSamplerProbabilistic(t *testing.T) {
 
 func TestDefaultSampler(t *testing.T) {
 	cfg := Configuration{
-		Sampler: &SamplerConfig{Type: "InvalidType"},
+		ServiceName: "test",
+		Sampler:     &SamplerConfig{Type: "InvalidType"},
 	}
-	_, _, err := cfg.New("testService")
+	_, _, err := cfg.NewTracer()
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidType")
+}
+
+func setEnv(t *testing.T, key, value string) {
+	require.NoError(t, os.Setenv(key, value))
+}
+
+func unsetEnv(t *testing.T, key string) {
+	require.NoError(t, os.Unsetenv(key))
+}
+
+func closeCloser(t *testing.T, c io.Closer) {
+	require.NoError(t, c.Close())
 }
 
 func TestServiceNameFromEnv(t *testing.T) {
-	os.Setenv(envServiceName, "my-service")
+	setEnv(t, envServiceName, "my-service")
 
 	cfg, err := FromEnv()
 	assert.NoError(t, err)
 
-	_, c, err := cfg.New("")
+	_, c, err := cfg.NewTracer()
 	assert.NoError(t, err)
-	defer c.Close()
-	os.Unsetenv(envServiceName)
+	defer closeCloser(t, c)
+	unsetEnv(t, envServiceName)
 }
 
 func TestConfigFromEnv(t *testing.T) {
@@ -105,10 +120,10 @@ func TestConfigFromEnv(t *testing.T) {
 	assert.Equal(t, "VALUE01", cfg.Tags[0].Value)
 
 	// prepare
-	os.Setenv(envServiceName, "my-service")
-	os.Setenv(envDisabled, "false")
-	os.Setenv(envRPCMetrics, "true")
-	os.Setenv(envTags, "KEY=VALUE")
+	setEnv(t, envServiceName, "my-service")
+	setEnv(t, envDisabled, "false")
+	setEnv(t, envRPCMetrics, "true")
+	setEnv(t, envTags, "KEY=VALUE")
 
 	// test with env set
 	cfg, err = cfg.FromEnv()
@@ -122,19 +137,19 @@ func TestConfigFromEnv(t *testing.T) {
 	assert.Equal(t, "VALUE", cfg.Tags[0].Value)
 
 	// cleanup
-	os.Unsetenv(envServiceName)
-	os.Unsetenv(envDisabled)
-	os.Unsetenv(envRPCMetrics)
-	os.Unsetenv(envTags)
+	unsetEnv(t, envServiceName)
+	unsetEnv(t, envDisabled)
+	unsetEnv(t, envRPCMetrics)
+	unsetEnv(t, envTags)
 }
 
 func TestSamplerConfig(t *testing.T) {
 	// prepare
-	os.Setenv(envSamplerType, "const")
-	os.Setenv(envSamplerParam, "1")
-	os.Setenv(envSamplerManagerHostPort, "http://themaster")
-	os.Setenv(envSamplerMaxOperations, "10")
-	os.Setenv(envSamplerRefreshInterval, "1m1s") // 61 seconds
+	setEnv(t, envSamplerType, "const")
+	setEnv(t, envSamplerParam, "1")
+	setEnv(t, envSamplerManagerHostPort, "http://themaster")
+	setEnv(t, envSamplerMaxOperations, "10")
+	setEnv(t, envSamplerRefreshInterval, "1m1s") // 61 seconds
 
 	//existing SamplerConfig data
 	sc := SamplerConfig{
@@ -153,15 +168,15 @@ func TestSamplerConfig(t *testing.T) {
 	assert.Equal(t, "const", cfg.Type)
 	assert.Equal(t, float64(1), cfg.Param)
 	assert.Equal(t, "http://themaster", cfg.SamplingServerURL)
-	assert.Equal(t, int(10), cfg.MaxOperations)
+	assert.Equal(t, 10, cfg.MaxOperations)
 	assert.Equal(t, 61000000000, int(cfg.SamplingRefreshInterval))
 
 	// cleanup
-	os.Unsetenv(envSamplerType)
-	os.Unsetenv(envSamplerParam)
-	os.Unsetenv(envSamplerManagerHostPort)
-	os.Unsetenv(envSamplerMaxOperations)
-	os.Unsetenv(envSamplerRefreshInterval)
+	unsetEnv(t, envSamplerType)
+	unsetEnv(t, envSamplerParam)
+	unsetEnv(t, envSamplerManagerHostPort)
+	unsetEnv(t, envSamplerMaxOperations)
+	unsetEnv(t, envSamplerRefreshInterval)
 }
 
 func TestSamplerConfigOptions(t *testing.T) {
@@ -180,13 +195,13 @@ func TestSamplerConfigOptions(t *testing.T) {
 
 func TestReporter(t *testing.T) {
 	// prepare
-	os.Setenv(envReporterMaxQueueSize, "10")
-	os.Setenv(envReporterFlushInterval, "1m1s") // 61 seconds
-	os.Setenv(envReporterLogSpans, "true")
-	os.Setenv(envAgentHost, "nonlocalhost")
-	os.Setenv(envAgentPort, "6832")
-	os.Setenv(envUser, "user")
-	os.Setenv(envPassword, "password")
+	setEnv(t, envReporterMaxQueueSize, "10")
+	setEnv(t, envReporterFlushInterval, "1m1s") // 61 seconds
+	setEnv(t, envReporterLogSpans, "true")
+	setEnv(t, envAgentHost, "nonlocalhost")
+	setEnv(t, envAgentPort, "6832")
+	setEnv(t, envUser, "user")
+	setEnv(t, envPassword, "password")
 
 	// Existing ReporterConfig data
 	rc := ReporterConfig{
@@ -204,7 +219,7 @@ func TestReporter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify
-	assert.Equal(t, int(10), cfg.QueueSize)
+	assert.Equal(t, 10, cfg.QueueSize)
 	assert.Equal(t, 61000000000, int(cfg.BufferFlushInterval))
 	assert.Equal(t, true, cfg.LogSpans)
 	assert.Equal(t, "nonlocalhost:6832", cfg.LocalAgentHostPort)
@@ -212,9 +227,9 @@ func TestReporter(t *testing.T) {
 	assert.Equal(t, "password01", cfg.Password)
 
 	// Prepare
-	os.Setenv(envEndpoint, "http://1.2.3.4:5678/api/traces")
-	os.Setenv(envUser, "user")
-	os.Setenv(envPassword, "password")
+	setEnv(t, envEndpoint, "http://1.2.3.4:5678/api/traces")
+	setEnv(t, envUser, "user")
+	setEnv(t, envPassword, "password")
 
 	// Existing ReprterConfig data for JAEGAR-ENDPOINT validation check
 	rc = ReporterConfig{
@@ -238,21 +253,21 @@ func TestReporter(t *testing.T) {
 	assert.Equal(t, "password", cfg.Password)
 
 	// cleanup
-	os.Unsetenv(envReporterMaxQueueSize)
-	os.Unsetenv(envReporterFlushInterval)
-	os.Unsetenv(envReporterLogSpans)
-	os.Unsetenv(envEndpoint)
-	os.Unsetenv(envUser)
-	os.Unsetenv(envPassword)
-	os.Unsetenv(envAgentHost)
-	os.Unsetenv(envAgentPort)
+	unsetEnv(t, envReporterMaxQueueSize)
+	unsetEnv(t, envReporterFlushInterval)
+	unsetEnv(t, envReporterLogSpans)
+	unsetEnv(t, envEndpoint)
+	unsetEnv(t, envUser)
+	unsetEnv(t, envPassword)
+	unsetEnv(t, envAgentHost)
+	unsetEnv(t, envAgentPort)
 }
 
 func TestFromEnv(t *testing.T) {
-	os.Setenv(envServiceName, "my-service")
-	os.Setenv(envDisabled, "false")
-	os.Setenv(envRPCMetrics, "true")
-	os.Setenv(envTags, "KEY=VALUE")
+	setEnv(t, envServiceName, "my-service")
+	setEnv(t, envDisabled, "false")
+	setEnv(t, envRPCMetrics, "true")
+	setEnv(t, envTags, "KEY=VALUE")
 
 	cfg, err := FromEnv()
 	assert.NoError(t, err)
@@ -262,35 +277,35 @@ func TestFromEnv(t *testing.T) {
 	assert.Equal(t, "KEY", cfg.Tags[0].Key)
 	assert.Equal(t, "VALUE", cfg.Tags[0].Value)
 
-	os.Unsetenv(envServiceName)
-	os.Unsetenv(envDisabled)
-	os.Unsetenv(envRPCMetrics)
-	os.Unsetenv(envTags)
+	unsetEnv(t, envServiceName)
+	unsetEnv(t, envDisabled)
+	unsetEnv(t, envRPCMetrics)
+	unsetEnv(t, envTags)
 }
 
 func TestNoServiceNameFromEnv(t *testing.T) {
-	os.Unsetenv(envServiceName)
+	unsetEnv(t, envServiceName)
 
 	cfg, err := FromEnv()
 	assert.NoError(t, err)
 
-	_, _, err = cfg.New("")
+	_, _, err = cfg.NewTracer()
 	assert.Error(t, err)
 
 	// However, if Disabled, then empty service name is irrelevant (issue #350)
 	cfg.Disabled = true
-	tr, _, err := cfg.New("")
+	tr, _, err := cfg.NewTracer()
 	assert.NoError(t, err)
 	assert.Equal(t, &opentracing.NoopTracer{}, tr)
 }
 
 func TestSamplerConfigFromEnv(t *testing.T) {
 	// prepare
-	os.Setenv(envSamplerType, "const")
-	os.Setenv(envSamplerParam, "1")
-	os.Setenv(envSamplerManagerHostPort, "http://themaster")
-	os.Setenv(envSamplerMaxOperations, "10")
-	os.Setenv(envSamplerRefreshInterval, "1m1s") // 61 seconds
+	setEnv(t, envSamplerType, "const")
+	setEnv(t, envSamplerParam, "1")
+	setEnv(t, envSamplerManagerHostPort, "http://themaster")
+	setEnv(t, envSamplerMaxOperations, "10")
+	setEnv(t, envSamplerRefreshInterval, "1m1s") // 61 seconds
 
 	// test
 	cfg, err := FromEnv()
@@ -300,20 +315,20 @@ func TestSamplerConfigFromEnv(t *testing.T) {
 	assert.Equal(t, "const", cfg.Sampler.Type)
 	assert.Equal(t, float64(1), cfg.Sampler.Param)
 	assert.Equal(t, "http://themaster", cfg.Sampler.SamplingServerURL)
-	assert.Equal(t, int(10), cfg.Sampler.MaxOperations)
+	assert.Equal(t, 10, cfg.Sampler.MaxOperations)
 	assert.Equal(t, 61000000000, int(cfg.Sampler.SamplingRefreshInterval))
 
 	// cleanup
-	os.Unsetenv(envSamplerType)
-	os.Unsetenv(envSamplerParam)
-	os.Unsetenv(envSamplerManagerHostPort)
-	os.Unsetenv(envSamplerMaxOperations)
-	os.Unsetenv(envSamplerRefreshInterval)
+	unsetEnv(t, envSamplerType)
+	unsetEnv(t, envSamplerParam)
+	unsetEnv(t, envSamplerManagerHostPort)
+	unsetEnv(t, envSamplerMaxOperations)
+	unsetEnv(t, envSamplerRefreshInterval)
 }
 
 func TestSamplerConfigOnAgentFromEnv(t *testing.T) {
 	// prepare
-	os.Setenv(envAgentHost, "theagent")
+	setEnv(t, envAgentHost, "theagent")
 
 	// test
 	cfg, err := FromEnv()
@@ -323,31 +338,31 @@ func TestSamplerConfigOnAgentFromEnv(t *testing.T) {
 	assert.Equal(t, "http://theagent:5778/sampling", cfg.Sampler.SamplingServerURL)
 
 	// cleanup
-	os.Unsetenv(envAgentHost)
+	unsetEnv(t, envAgentHost)
 }
 
 func TestReporterConfigFromEnv(t *testing.T) {
 	// prepare
-	os.Setenv(envReporterMaxQueueSize, "10")
-	os.Setenv(envReporterFlushInterval, "1m1s") // 61 seconds
-	os.Setenv(envReporterLogSpans, "true")
-	os.Setenv(envAgentHost, "nonlocalhost")
-	os.Setenv(envAgentPort, "6832")
+	setEnv(t, envReporterMaxQueueSize, "10")
+	setEnv(t, envReporterFlushInterval, "1m1s") // 61 seconds
+	setEnv(t, envReporterLogSpans, "true")
+	setEnv(t, envAgentHost, "nonlocalhost")
+	setEnv(t, envAgentPort, "6832")
 
 	// test
 	cfg, err := FromEnv()
 	assert.NoError(t, err)
 
 	// verify
-	assert.Equal(t, int(10), cfg.Reporter.QueueSize)
+	assert.Equal(t, 10, cfg.Reporter.QueueSize)
 	assert.Equal(t, 61000000000, int(cfg.Reporter.BufferFlushInterval))
 	assert.Equal(t, true, cfg.Reporter.LogSpans)
 	assert.Equal(t, "nonlocalhost:6832", cfg.Reporter.LocalAgentHostPort)
 
 	// Test HTTP transport
-	os.Setenv(envEndpoint, "http://1.2.3.4:5678/api/traces")
-	os.Setenv(envUser, "user")
-	os.Setenv(envPassword, "password")
+	setEnv(t, envEndpoint, "http://1.2.3.4:5678/api/traces")
+	setEnv(t, envUser, "user")
+	setEnv(t, envPassword, "password")
 
 	// test
 	cfg, err = FromEnv()
@@ -360,16 +375,16 @@ func TestReporterConfigFromEnv(t *testing.T) {
 	assert.Equal(t, "", cfg.Reporter.LocalAgentHostPort)
 
 	// cleanup
-	os.Unsetenv(envReporterMaxQueueSize)
-	os.Unsetenv(envReporterFlushInterval)
-	os.Unsetenv(envReporterLogSpans)
-	os.Unsetenv(envEndpoint)
-	os.Unsetenv(envUser)
-	os.Unsetenv(envPassword)
+	unsetEnv(t, envReporterMaxQueueSize)
+	unsetEnv(t, envReporterFlushInterval)
+	unsetEnv(t, envReporterLogSpans)
+	unsetEnv(t, envEndpoint)
+	unsetEnv(t, envUser)
+	unsetEnv(t, envPassword)
 }
 
 func TestParsingErrorsFromEnv(t *testing.T) {
-	os.Setenv(envAgentHost, "localhost") // we require this in order to test the parsing of the port
+	setEnv(t, envAgentHost, "localhost") // we require this in order to test the parsing of the port
 
 	tests := []struct {
 		envVar string
@@ -418,15 +433,15 @@ func TestParsingErrorsFromEnv(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		os.Setenv(test.envVar, test.value)
+		setEnv(t, test.envVar, test.value)
 		if test.envVar == envEndpoint {
-			os.Unsetenv(envAgentHost)
-			os.Unsetenv(envAgentPort)
+			unsetEnv(t, envAgentHost)
+			unsetEnv(t, envAgentPort)
 		}
 		_, err := FromEnv()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), fmt.Sprintf("cannot parse env var %s=%s", test.envVar, test.value))
-		os.Unsetenv(test.envVar)
+		unsetEnv(t, test.envVar)
 	}
 
 }
@@ -445,16 +460,16 @@ func TestParsingUserPasswordErrorEnv(t *testing.T) {
 			value:  "password",
 		},
 	}
-	os.Setenv(envEndpoint, "http://localhost:8080")
+	setEnv(t, envEndpoint, "http://localhost:8080")
 	for _, test := range tests {
-		os.Setenv(test.envVar, test.value)
+		setEnv(t, test.envVar, test.value)
 		_, err := FromEnv()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), fmt.Sprintf("you must set %s and %s env vars together", envUser,
 			envPassword))
-		os.Unsetenv(test.envVar)
+		unsetEnv(t, test.envVar)
 	}
-	os.Unsetenv(envEndpoint)
+	unsetEnv(t, envEndpoint)
 }
 
 func TestInvalidSamplerType(t *testing.T) {
@@ -484,26 +499,28 @@ func TestHTTPTransportType(t *testing.T) {
 
 func TestDefaultConfig(t *testing.T) {
 	cfg := Configuration{}
-	_, _, err := cfg.New("", Metrics(metrics.NullFactory), Logger(log.NullLogger))
+	_, _, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger))
 	require.EqualError(t, err, "no service name provided")
 
-	_, closer, err := cfg.New("testService")
-	defer closer.Close()
+	cfg.ServiceName = "test"
+	_, closer, err := cfg.NewTracer()
+	defer closeCloser(t, closer)
 	require.NoError(t, err)
 }
 
 func TestDisabledFlag(t *testing.T) {
-	cfg := Configuration{Disabled: true}
-	_, closer, err := cfg.New("testService")
-	defer closer.Close()
+	cfg := Configuration{ServiceName: "test", Disabled: true}
+	_, closer, err := cfg.NewTracer()
+	defer closeCloser(t, closer)
 	require.NoError(t, err)
 }
 
 func TestNewReporterError(t *testing.T) {
 	cfg := Configuration{
-		Reporter: &ReporterConfig{LocalAgentHostPort: "bad_local_agent"},
+		ServiceName: "test",
+		Reporter:    &ReporterConfig{LocalAgentHostPort: "bad_local_agent"},
 	}
-	_, _, err := cfg.New("testService")
+	_, _, err := cfg.NewTracer()
 	require.Error(t, err)
 }
 
@@ -562,23 +579,25 @@ func TestInitGlobalTracer(t *testing.T) {
 
 func TestConfigWithReporter(t *testing.T) {
 	c := Configuration{
+		ServiceName: "test",
 		Sampler: &SamplerConfig{
 			Type:  "const",
 			Param: 1,
 		},
 	}
 	r := jaeger.NewInMemoryReporter()
-	tracer, closer, err := c.New("test", Reporter(r))
+	tracer, closer, err := c.NewTracer(Reporter(r))
 	require.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	tracer.StartSpan("test").Finish()
 	assert.Len(t, r.GetSpans(), 1)
 }
 
 func TestConfigWithRPCMetrics(t *testing.T) {
-	metrics := metricstest.NewFactory(0)
+	m := metricstest.NewFactory(0)
 	c := Configuration{
+		ServiceName: "test",
 		Sampler: &SamplerConfig{
 			Type:  "const",
 			Param: 1,
@@ -586,18 +605,17 @@ func TestConfigWithRPCMetrics(t *testing.T) {
 		RPCMetrics: true,
 	}
 	r := jaeger.NewInMemoryReporter()
-	tracer, closer, err := c.New(
-		"test",
+	tracer, closer, err := c.NewTracer(
 		Reporter(r),
-		Metrics(metrics),
+		Metrics(m),
 		ContribObserver(fakeContribObserver{}),
 	)
 	require.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	tracer.StartSpan("test", ext.SpanKindRPCServer).Finish()
 
-	metrics.AssertCounterMetrics(t,
+	m.AssertCounterMetrics(t,
 		metricstest.ExpectedMetric{
 			Name:  "jaeger-rpc.requests",
 			Tags:  map[string]string{"component": "jaeger", "endpoint": "test", "error": "false"},
@@ -609,17 +627,15 @@ func TestConfigWithRPCMetrics(t *testing.T) {
 func TestBaggageRestrictionsConfig(t *testing.T) {
 	m := metricstest.NewFactory(0)
 	c := Configuration{
+		ServiceName: "test",
 		BaggageRestrictions: &BaggageRestrictionsConfig{
 			HostPort:        "not:1929213",
 			RefreshInterval: time.Minute,
 		},
 	}
-	_, closer, err := c.New(
-		"test",
-		Metrics(m),
-	)
+	_, closer, err := c.NewTracer(Metrics(m))
 	require.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	metricName := "jaeger.tracer.baggage_restrictions_updates"
 	metricTags := map[string]string{"result": "err"}
@@ -644,15 +660,16 @@ func TestBaggageRestrictionsConfig(t *testing.T) {
 
 func TestConfigWithGen128Bit(t *testing.T) {
 	c := Configuration{
+		ServiceName: "test",
 		Sampler: &SamplerConfig{
 			Type:  "const",
 			Param: 1,
 		},
 		RPCMetrics: true,
 	}
-	tracer, closer, err := c.New("test", Gen128Bit(true))
+	tracer, closer, err := c.NewTracer(Gen128Bit(true))
 	require.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	span := tracer.StartSpan("test")
 	defer span.Finish()
@@ -662,10 +679,10 @@ func TestConfigWithGen128Bit(t *testing.T) {
 }
 
 func TestConfigWithInjector(t *testing.T) {
-	c := Configuration{}
-	tracer, closer, err := c.New("test", Injector("custom.format", fakeInjector{}))
+	c := Configuration{ServiceName: "test"}
+	tracer, closer, err := c.NewTracer(Injector("custom.format", fakeInjector{}))
 	require.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	span := tracer.StartSpan("test")
 	defer span.Finish()
@@ -678,10 +695,10 @@ func TestConfigWithInjector(t *testing.T) {
 }
 
 func TestConfigWithExtractor(t *testing.T) {
-	c := Configuration{}
-	tracer, closer, err := c.New("test", Extractor("custom.format", fakeExtractor{}))
+	c := Configuration{ServiceName: "test"}
+	tracer, closer, err := c.NewTracer(Extractor("custom.format", fakeExtractor{}))
 	require.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	_, err = tracer.Extract("unknown.format", nil)
 	require.Error(t, err)
@@ -691,12 +708,12 @@ func TestConfigWithExtractor(t *testing.T) {
 }
 
 func TestConfigWithSampler(t *testing.T) {
-	c := Configuration{}
+	c := Configuration{ServiceName: "test"}
 	sampler := &fakeSampler{}
 
-	tracer, closer, err := c.New("test", Sampler(sampler))
+	tracer, closer, err := c.NewTracer(Sampler(sampler))
 	require.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	span := tracer.StartSpan("test")
 	defer span.Finish()
@@ -709,7 +726,7 @@ func TestConfigWithSampler(t *testing.T) {
 func TestNewTracer(t *testing.T) {
 	cfg := &Configuration{ServiceName: "my-service"}
 	_, closer, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger))
-	defer closer.Close()
+	defer closeCloser(t, closer)
 
 	assert.NoError(t, err)
 }
@@ -717,7 +734,10 @@ func TestNewTracer(t *testing.T) {
 func TestNewTracerWithNoDebugFlagOnForcedSampling(t *testing.T) {
 	cfg := &Configuration{ServiceName: "my-service"}
 	tracer, closer, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger), NoDebugFlagOnForcedSampling(true))
-	defer closer.Close()
+	require.NoError(t, err)
+	require.NotNil(t, tracer)
+	require.NotNil(t, closer)
+	defer closeCloser(t, closer)
 
 	span := tracer.StartSpan("testSpan").(*jaeger.Span)
 	ext.SamplingPriority.Set(span, 1)
@@ -730,11 +750,12 @@ func TestNewTracerWithNoDebugFlagOnForcedSampling(t *testing.T) {
 func TestNewTracerWithoutServiceName(t *testing.T) {
 	cfg := &Configuration{}
 	_, _, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger))
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no service name provided")
 }
 
 func TestParseTags(t *testing.T) {
-	os.Setenv("existing", "not-default")
+	setEnv(t, "existing", "not-default")
 	tags := "key=value,k1=${nonExisting:default}, k2=${withSpace:default},k3=${existing:default}"
 	ts := parseTags(tags)
 	assert.Equal(t, 4, len(ts))
@@ -751,28 +772,29 @@ func TestParseTags(t *testing.T) {
 	assert.Equal(t, "k3", ts[3].Key)
 	assert.Equal(t, "not-default", ts[3].Value)
 
-	os.Unsetenv("existing")
+	unsetEnv(t, "existing")
 }
 
 func TestServiceNameViaConfiguration(t *testing.T) {
 	cfg := &Configuration{ServiceName: "my-service"}
 	_, closer, err := cfg.New("")
 	assert.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 }
 
 func TestTracerTags(t *testing.T) {
-	cfg := &Configuration{Tags: []opentracing.Tag{{Key: "test", Value: 123}}}
-	_, closer, err := cfg.New("test-service")
+	cfg := &Configuration{ServiceName: "test-service", Tags: []opentracing.Tag{{Key: "test", Value: 123}}}
+	_, closer, err := cfg.NewTracer()
 	assert.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 }
 
 func TestThrottlerDefaultConfig(t *testing.T) {
 	cfg := &Configuration{
-		Throttler: &ThrottlerConfig{},
+		ServiceName: "test-service",
+		Throttler:   &ThrottlerConfig{},
 	}
-	_, closer, err := cfg.New("test-service")
+	_, closer, err := cfg.NewTracer()
 	assert.NoError(t, err)
-	defer closer.Close()
+	defer closeCloser(t, closer)
 }

--- a/sampler.go
+++ b/sampler.go
@@ -363,7 +363,7 @@ type PerOperationSamplerParams struct {
 
 // NewPerOperationSampler returns a new PerOperationSampler.
 func NewPerOperationSampler(params PerOperationSamplerParams) *PerOperationSampler {
-	if params.MaxOperations == 0 {
+	if params.MaxOperations <= 0 {
 		params.MaxOperations = defaultMaxOperations
 	}
 	samplers := make(map[string]*GuaranteedThroughputProbabilisticSampler)

--- a/sampler.go
+++ b/sampler.go
@@ -363,6 +363,9 @@ type PerOperationSamplerParams struct {
 
 // NewPerOperationSampler returns a new PerOperationSampler.
 func NewPerOperationSampler(params PerOperationSamplerParams) *PerOperationSampler {
+	if params.MaxOperations == 0 {
+		params.MaxOperations = defaultMaxOperations
+	}
 	samplers := make(map[string]*GuaranteedThroughputProbabilisticSampler)
 	for _, strategy := range params.Strategies.PerOperationStrategies {
 		sampler := newGuaranteedThroughputProbabilisticSampler(

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -258,8 +258,9 @@ func (u *RateLimitingSamplerUpdater) Update(sampler SamplerV2, strategy interfac
 // -----------------------
 
 // AdaptiveSamplerUpdater is used by RemotelyControlledSampler to parse sampling configuration.
+// Fields have the same meaning as in PerOperationSamplerParams.
 type AdaptiveSamplerUpdater struct {
-	MaxOperations            int // required
+	MaxOperations            int
 	OperationNameLateBinding bool
 }
 

--- a/sampler_remote_options.go
+++ b/sampler_remote_options.go
@@ -27,7 +27,9 @@ type SamplerOption func(options *samplerOptions)
 var SamplerOptions SamplerOptionsFactory
 
 // SamplerOptionsFactory is a factory for all available SamplerOption's.
-// The type acts as a namespace for factory functions.
+// The type acts as a namespace for factory functions. It is public to
+// make the functions discoverable via godoc. Recommended to be used
+// via global SamplerOptions variable.
 type SamplerOptionsFactory struct{}
 
 type samplerOptions struct {
@@ -127,9 +129,6 @@ func (o *samplerOptions) applyOptionsAndDefaults(opts ...SamplerOption) *sampler
 	}
 	if o.logger == nil {
 		o.logger = log.NullLogger
-	}
-	if o.posParams.MaxOperations <= 0 {
-		o.posParams.MaxOperations = defaultMaxOperations
 	}
 	if o.samplingServerURL == "" {
 		o.samplingServerURL = DefaultSamplingServerURL

--- a/sampler_remote_options.go
+++ b/sampler_remote_options.go
@@ -23,12 +23,15 @@ import (
 // SamplerOption is a function that sets some option on the sampler
 type SamplerOption func(options *samplerOptions)
 
-// SamplerOptions is a factory for all available SamplerOption's
-var SamplerOptions samplerOptions
+// SamplerOptions is a factory for all available SamplerOption's.
+var SamplerOptions SamplerOptionsFactory
+
+// SamplerOptionsFactory is a factory for all available SamplerOption's.
+// The type acts as a namespace for factory functions.
+type SamplerOptionsFactory struct{}
 
 type samplerOptions struct {
 	metrics                 *Metrics
-	maxOperations           int
 	sampler                 SamplerV2
 	logger                  Logger
 	samplingServerURL       string
@@ -36,11 +39,12 @@ type samplerOptions struct {
 	samplingFetcher         SamplingStrategyFetcher
 	samplingParser          SamplingStrategyParser
 	updaters                []SamplerUpdater
+	posParams               PerOperationSamplerParams
 }
 
 // Metrics creates a SamplerOption that initializes Metrics on the sampler,
 // which is used to emit statistics.
-func (samplerOptions) Metrics(m *Metrics) SamplerOption {
+func (SamplerOptionsFactory) Metrics(m *Metrics) SamplerOption {
 	return func(o *samplerOptions) {
 		o.metrics = m
 	}
@@ -48,22 +52,30 @@ func (samplerOptions) Metrics(m *Metrics) SamplerOption {
 
 // MaxOperations creates a SamplerOption that sets the maximum number of
 // operations the sampler will keep track of.
-func (samplerOptions) MaxOperations(maxOperations int) SamplerOption {
+func (SamplerOptionsFactory) MaxOperations(maxOperations int) SamplerOption {
 	return func(o *samplerOptions) {
-		o.maxOperations = maxOperations
+		o.posParams.MaxOperations = maxOperations
+	}
+}
+
+// OperationNameLateBinding creates a SamplerOption that sets the respective
+// field in the PerOperationSamplerParams.
+func (SamplerOptionsFactory) OperationNameLateBinding(enable bool) SamplerOption {
+	return func(o *samplerOptions) {
+		o.posParams.OperationNameLateBinding = enable
 	}
 }
 
 // InitialSampler creates a SamplerOption that sets the initial sampler
 // to use before a remote sampler is created and used.
-func (samplerOptions) InitialSampler(sampler Sampler) SamplerOption {
+func (SamplerOptionsFactory) InitialSampler(sampler Sampler) SamplerOption {
 	return func(o *samplerOptions) {
 		o.sampler = samplerV1toV2(sampler)
 	}
 }
 
 // Logger creates a SamplerOption that sets the logger used by the sampler.
-func (samplerOptions) Logger(logger Logger) SamplerOption {
+func (SamplerOptionsFactory) Logger(logger Logger) SamplerOption {
 	return func(o *samplerOptions) {
 		o.logger = logger
 	}
@@ -71,7 +83,7 @@ func (samplerOptions) Logger(logger Logger) SamplerOption {
 
 // SamplingServerURL creates a SamplerOption that sets the sampling server url
 // of the local agent that contains the sampling strategies.
-func (samplerOptions) SamplingServerURL(samplingServerURL string) SamplerOption {
+func (SamplerOptionsFactory) SamplingServerURL(samplingServerURL string) SamplerOption {
 	return func(o *samplerOptions) {
 		o.samplingServerURL = samplingServerURL
 	}
@@ -79,28 +91,28 @@ func (samplerOptions) SamplingServerURL(samplingServerURL string) SamplerOption 
 
 // SamplingRefreshInterval creates a SamplerOption that sets how often the
 // sampler will poll local agent for the appropriate sampling strategy.
-func (samplerOptions) SamplingRefreshInterval(samplingRefreshInterval time.Duration) SamplerOption {
+func (SamplerOptionsFactory) SamplingRefreshInterval(samplingRefreshInterval time.Duration) SamplerOption {
 	return func(o *samplerOptions) {
 		o.samplingRefreshInterval = samplingRefreshInterval
 	}
 }
 
 // SamplingStrategyFetcher creates a SamplerOption that initializes sampling strategy fetcher.
-func (samplerOptions) SamplingStrategyFetcher(fetcher SamplingStrategyFetcher) SamplerOption {
+func (SamplerOptionsFactory) SamplingStrategyFetcher(fetcher SamplingStrategyFetcher) SamplerOption {
 	return func(o *samplerOptions) {
 		o.samplingFetcher = fetcher
 	}
 }
 
 // SamplingStrategyParser creates a SamplerOption that initializes sampling strategy parser.
-func (samplerOptions) SamplingStrategyParser(parser SamplingStrategyParser) SamplerOption {
+func (SamplerOptionsFactory) SamplingStrategyParser(parser SamplingStrategyParser) SamplerOption {
 	return func(o *samplerOptions) {
 		o.samplingParser = parser
 	}
 }
 
 // Updaters creates a SamplerOption that initializes sampler updaters.
-func (samplerOptions) Updaters(updaters ...SamplerUpdater) SamplerOption {
+func (SamplerOptionsFactory) Updaters(updaters ...SamplerUpdater) SamplerOption {
 	return func(o *samplerOptions) {
 		o.updaters = updaters
 	}
@@ -116,8 +128,8 @@ func (o *samplerOptions) applyOptionsAndDefaults(opts ...SamplerOption) *sampler
 	if o.logger == nil {
 		o.logger = log.NullLogger
 	}
-	if o.maxOperations <= 0 {
-		o.maxOperations = defaultMaxOperations
+	if o.posParams.MaxOperations <= 0 {
+		o.posParams.MaxOperations = defaultMaxOperations
 	}
 	if o.samplingServerURL == "" {
 		o.samplingServerURL = DefaultSamplingServerURL
@@ -139,7 +151,10 @@ func (o *samplerOptions) applyOptionsAndDefaults(opts ...SamplerOption) *sampler
 	}
 	if o.updaters == nil {
 		o.updaters = []SamplerUpdater{
-			&AdaptiveSamplerUpdater{MaxOperations: o.maxOperations},
+			&AdaptiveSamplerUpdater{
+				MaxOperations:            o.posParams.MaxOperations,
+				OperationNameLateBinding: o.posParams.OperationNameLateBinding,
+			},
 			new(ProbabilisticSamplerUpdater),
 			new(RateLimitingSamplerUpdater),
 		}

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -29,7 +29,39 @@ import (
 	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
 )
 
-func TestApplySamplerOptions(t *testing.T) {
+func TestRemoteSamplerOptions(t *testing.T) {
+	m := new(Metrics)
+	initSampler, _ := NewProbabilisticSampler(0.123)
+	logger := new(nullLogger)
+	fetcher := new(fakeSamplingFetcher)
+	parser := new(samplingStrategyParser)
+	updaters := []SamplerUpdater{new(ProbabilisticSamplerUpdater)}
+	sampler := NewRemotelyControlledSampler(
+		"test",
+		SamplerOptions.Metrics(m),
+		SamplerOptions.MaxOperations(42),
+		SamplerOptions.OperationNameLateBinding(true),
+		SamplerOptions.InitialSampler(initSampler),
+		SamplerOptions.Logger(logger),
+		SamplerOptions.SamplingServerURL("my url"),
+		SamplerOptions.SamplingRefreshInterval(42*time.Second),
+		SamplerOptions.SamplingStrategyFetcher(fetcher),
+		SamplerOptions.SamplingStrategyParser(parser),
+		SamplerOptions.Updaters(updaters...),
+	)
+	assert.Same(t, m, sampler.metrics)
+	assert.Equal(t, 42, sampler.posParams.MaxOperations)
+	assert.True(t, sampler.posParams.OperationNameLateBinding)
+	assert.Same(t, initSampler, sampler.Sampler())
+	assert.Same(t, logger, sampler.logger)
+	assert.Equal(t, "my url", sampler.samplingServerURL)
+	assert.Equal(t, 42*time.Second, sampler.samplingRefreshInterval)
+	assert.Same(t, fetcher, sampler.samplingFetcher)
+	assert.Same(t, parser, sampler.samplingParser)
+	assert.Same(t, updaters[0], sampler.updaters[0])
+}
+
+func TestRemoteSamplerOptionsDefaults(t *testing.T) {
 	options := new(samplerOptions).applyOptionsAndDefaults()
 	sampler, ok := options.sampler.(*ProbabilisticSampler)
 	assert.True(t, ok)

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -471,6 +471,5 @@ func TestRemotelyControlledSampler_printErrorForBrokenUpstream(t *testing.T) {
 	)
 	sampler.Close() // stop timer-based updates, we want to call them manually
 	sampler.UpdateSampler()
-
 	assert.Contains(t, logger.String(), "failed to fetch sampling strategy:")
 }

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -36,7 +36,6 @@ func TestApplySamplerOptions(t *testing.T) {
 	assert.Equal(t, 0.001, sampler.samplingRate)
 
 	assert.NotNil(t, options.logger)
-	assert.NotZero(t, options.posParams.MaxOperations)
 	assert.NotEmpty(t, options.samplingServerURL)
 	assert.NotNil(t, options.metrics)
 	assert.NotZero(t, options.samplingRefreshInterval)

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -36,7 +36,7 @@ func TestApplySamplerOptions(t *testing.T) {
 	assert.Equal(t, 0.001, sampler.samplingRate)
 
 	assert.NotNil(t, options.logger)
-	assert.NotZero(t, options.maxOperations)
+	assert.NotZero(t, options.posParams.MaxOperations)
 	assert.NotEmpty(t, options.samplingServerURL)
 	assert.NotNil(t, options.metrics)
 	assert.NotZero(t, options.samplingRefreshInterval)
@@ -468,6 +468,7 @@ func TestRemotelyControlledSampler_printErrorForBrokenUpstream(t *testing.T) {
 	sampler := NewRemotelyControlledSampler(
 		"client app",
 		SamplerOptions.Logger(logger),
+		SamplerOptions.SamplingServerURL("invalid address"),
 	)
 	sampler.Close() // stop timer-based updates, we want to call them manually
 	sampler.UpdateSampler()

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -165,6 +165,11 @@ func TestAdaptiveSampler(t *testing.T) {
 	sampler, err := NewAdaptiveSampler(strategies, 42)
 	require.NoError(t, err, "deprecated constructor successful")
 	assert.Equal(t, 42, sampler.maxOperations)
+	sampler.Close()
+
+	sampler = NewPerOperationSampler(PerOperationSamplerParams{Strategies: strategies})
+	assert.Equal(t, sampler.maxOperations, 2000, "default MaxOperations applied")
+	sampler.Close()
 
 	sampler = NewPerOperationSampler(PerOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,


### PR DESCRIPTION
## Short description of the changes
- Make AdaptiveSamplerUpdater usable with default values; Resolves #467
- Create `OperationNameLateBinding` sampler option and config option
- Make `SamplerOptions` var of public type, so that its functions are discoverable via godoc
