### PR TITLE
Clarify reporting error logs

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -263,7 +263,7 @@ func (r *remoteReporter) processQueue() {
 	flush := func() {
 		if flushed, err := r.sender.Flush(); err != nil {
 			r.metrics.ReporterFailure.Inc(int64(flushed))
-			r.logger.Error(fmt.Sprintf("error when flushing the buffer: %s", err.Error()))
+			r.logger.Error(fmt.Sprintf("failed to flush Jaeger spans to server: %s", err.Error()))
 		} else if flushed > 0 {
 			r.metrics.ReporterSuccess.Inc(int64(flushed))
 		}
@@ -281,7 +281,7 @@ func (r *remoteReporter) processQueue() {
 				span := item.span
 				if flushed, err := r.sender.Append(span); err != nil {
 					r.metrics.ReporterFailure.Inc(int64(flushed))
-					r.logger.Error(fmt.Sprintf("error reporting span %q: %s", span.OperationName(), err.Error()))
+					r.logger.Error(fmt.Sprintf("error reporting Jaeger span %q: %s", span.OperationName(), err.Error()))
 				} else if flushed > 0 {
 					r.metrics.ReporterSuccess.Inc(int64(flushed))
 					// to reduce the number of gauge stats, we only emit queue length on flush

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -136,11 +136,11 @@ func TestRemoteReporterFailedFlushViaAppend(t *testing.T) {
 	s.tracer.StartSpan("sp1").Finish()
 	s.tracer.StartSpan("sp2").Finish()
 	s.sender.assertFlushedSpans(t, 2)
-	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\n")
+	s.assertLogs(t, "ERROR: error reporting Jaeger span \"sp2\": flush error\n")
 	s.assertCounter(t, "jaeger.tracer.reporter_spans", map[string]string{"result": "err"}, 2)
 	s.assertCounter(t, "jaeger.tracer.reporter_spans", map[string]string{"result": "ok"}, 0)
 	s.close() // causes explicit flush that also fails with the same error
-	s.assertLogs(t, "ERROR: error reporting span \"sp2\": flush error\nERROR: error when flushing the buffer: flush error\n")
+	s.assertLogs(t, "ERROR: error reporting Jaeger span \"sp2\": flush error\nERROR: failed to flush Jaeger spans to server: flush error\n")
 }
 
 func TestRemoteReporterAppendWithPoolAllocator(t *testing.T) {

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -139,7 +139,7 @@ func TestHTTPErrorLogging(t *testing.T) {
 		},
 		{ // bad URL scheme
 			URL:                   "badscheme://localhost:10001",
-			expectErrorSubstrings: []string{"error when flushing the buffer"},
+			expectErrorSubstrings: []string{"failed to flush Jaeger spans to server"},
 		},
 	}
 


### PR DESCRIPTION
Tweak log messages to make it obvious they are coming from Jaeger