### PR TITLE
Don't overwrite existing AgentHostPort by default value if env not set

### DIFF
--- a/config/config_env.go
+++ b/config/config_env.go
@@ -184,20 +184,31 @@ func (rc *ReporterConfig) reporterConfigFromEnv() (*ReporterConfig, error) {
 		rc.User = user
 		rc.Password = pswd
 	} else {
-		host := jaeger.DefaultUDPSpanServerHost
+		var host string
+		var port int
+		var isDefaultHost, isDefaultPort bool
+
 		if e := os.Getenv(envAgentHost); e != "" {
 			host = e
+		} else {
+			host = jaeger.DefaultUDPSpanServerHost
+			isDefaultHost = true
 		}
 
-		port := jaeger.DefaultUDPSpanServerPort
 		if e := os.Getenv(envAgentPort); e != "" {
 			if value, err := strconv.ParseInt(e, 10, 0); err == nil {
 				port = int(value)
 			} else {
 				return nil, errors.Wrapf(err, "cannot parse env var %s=%s", envAgentPort, e)
 			}
+		} else {
+			port = jaeger.DefaultUDPSpanServerPort
+			isDefaultPort = true
 		}
-		rc.LocalAgentHostPort = fmt.Sprintf("%s:%d", host, port)
+
+		if rc.LocalAgentHostPort == "" || !isDefaultHost || !isDefaultPort {
+			rc.LocalAgentHostPort = fmt.Sprintf("%s:%d", host, port)
+		}
 	}
 
 	return rc, nil


### PR DESCRIPTION
Signed-off-by: Cui Haikuo <haikuo_cui@shannonai.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #473 

## Short description of the changes
- In ReporterConfig.reporterConfigFromEnv(),  if the config struct already has a value and env not set then the default value should not override what's in the struct.
