### PR TITLE
chore(docs): fixed a couple of typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and [config/example_test.go](./config/example_test.go).
 ### Environment variables
 
 The tracer can be initialized with values coming from environment variables. None of the env vars are required
-and all of them can be overriden via direct setting of the property on the configuration object.
+and all of them can be overridden via direct setting of the property on the configuration object.
 
 Property| Description
 --- | ---

--- a/thrift-gen/zipkincore/ttypes.go
+++ b/thrift-gen/zipkincore/ttypes.go
@@ -729,7 +729,7 @@ func (p *BinaryAnnotation) String() string {
 // precise value possible. For example, gettimeofday or syncing nanoTime
 // against a tick of currentTimeMillis.
 //
-// For compatibilty with instrumentation that precede this field, collectors
+// For compatibility with instrumentation that precede this field, collectors
 // or span stores can derive this via Annotation.timestamp.
 // For example, SERVER_RECV.timestamp or CLIENT_SEND.timestamp.
 //
@@ -741,7 +741,7 @@ func (p *BinaryAnnotation) String() string {
 // precise measurement decoupled from problems of clocks, such as skew or NTP
 // updates causing time to move backwards.
 //
-// For compatibilty with instrumentation that precede this field, collectors
+// For compatibiltiy with instrumentation that precede this field, collectors
 // or span stores can derive this by subtracting Annotation.timestamp.
 // For example, SERVER_SEND.timestamp - SERVER_RECV.timestamp.
 //

--- a/thrift-gen/zipkincore/ttypes.go
+++ b/thrift-gen/zipkincore/ttypes.go
@@ -729,7 +729,7 @@ func (p *BinaryAnnotation) String() string {
 // precise value possible. For example, gettimeofday or syncing nanoTime
 // against a tick of currentTimeMillis.
 //
-// For compatibility with instrumentation that precede this field, collectors
+// For compatibilty with instrumentation that precede this field, collectors
 // or span stores can derive this via Annotation.timestamp.
 // For example, SERVER_RECV.timestamp or CLIENT_SEND.timestamp.
 //
@@ -741,7 +741,7 @@ func (p *BinaryAnnotation) String() string {
 // precise measurement decoupled from problems of clocks, such as skew or NTP
 // updates causing time to move backwards.
 //
-// For compatibiltiy with instrumentation that precede this field, collectors
+// For compatibilty with instrumentation that precede this field, collectors
 // or span stores can derive this by subtracting Annotation.timestamp.
 // For example, SERVER_SEND.timestamp - SERVER_RECV.timestamp.
 //


### PR DESCRIPTION
Signed-off-by: Marc Bramaud <m.duboucheron@gmail.com>

## Which problem is this PR solving?
- ~3~ 1 typos in `README.md` ~and `thrift-gen/zipkincore/ttypes.go`~

