### PR TITLE
Unfinished span counter and logging tests

### DIFF
--- a/tracer_test.go
+++ b/tracer_test.go
@@ -45,7 +45,6 @@ func (s *tracerSuite) SetupTest() {
 	s.metricsFactory = metricstest.NewFactory(0)
 	metrics := NewMetrics(s.metricsFactory, nil)
 	s.logger = &log.BytesBufferLogger{}
-
 	s.tracer, s.closer = NewTracer("DOOP", // respect the classics, man!
 		NewConstSampler(true),
 		NewNullReporter(),
@@ -139,7 +138,7 @@ func (s *tracerSuite) TestUnfinishedSpanCounter() {
 	s.tracer.StartSpan("get_name")
 	s.closer.Close()
 
-	s.Equal(s.tracer.(*Tracer).UnfinishedSpanCounter, uint32(1))
+	s.Equal(int32(1), s.tracer.(*Tracer).UnfinishedSpanCounter)
 	s.metricsFactory.AssertCounterMetrics(s.T(), []metricstest.ExpectedMetric{
 		{Name: "jaeger.tracer.started_spans", Tags: map[string]string{"sampled": "y"}, Value: 1},
 		{Name: "jaeger.tracer.finished_spans", Tags: map[string]string{"sampled": "y"}, Value: 0},


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
This PR add a counter for unfinished/partial Span (showing a log.error for the user), so developers can be aware of these situations.

Related task. https://github.com/jaegertracing/jaeger/issues/698

## Short description of the changes
Add a new integer counter on Tracer, maybe makes sense to use the metrics already in the system instead.
