### PR TITLE
Provide ability for clients to add HTTP headers

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -497,6 +497,18 @@ func TestHTTPTransportType(t *testing.T) {
 	require.IsType(t, expect, sender)
 }
 
+func TestHTTPTransportTypeWithAuth(t *testing.T) {
+	rc := &ReporterConfig{
+		CollectorEndpoint: "http://1.2.3.4:5678/api/traces",
+		User:              "auth_user",
+		Password:          "auth_pass",
+	}
+	expect := transport.NewHTTPTransport(rc.CollectorEndpoint)
+	sender, err := rc.newTransport()
+	require.NoError(t, err)
+	require.IsType(t, expect, sender)
+}
+
 func TestDefaultConfig(t *testing.T) {
 	cfg := Configuration{}
 	_, _, err := cfg.NewTracer(Metrics(metrics.NullFactory), Logger(log.NullLogger))

--- a/transport/http.go
+++ b/transport/http.go
@@ -39,6 +39,7 @@ type HTTPTransport struct {
 	spans           []*j.Span
 	process         *j.Process
 	httpCredentials *HTTPBasicAuthCredentials
+	headers         map[string]string
 }
 
 // HTTPBasicAuthCredentials stores credentials for HTTP basic auth.
@@ -73,6 +74,13 @@ func HTTPBasicAuth(username string, password string) HTTPOption {
 func HTTPRoundTripper(transport http.RoundTripper) HTTPOption {
 	return func(c *HTTPTransport) {
 		c.client.Transport = transport
+	}
+}
+
+// HTTPHeaders defines the HTTP headers that will be attached to the jaeger client's HTTP request
+func HTTPHeaders(headers map[string]string) HTTPOption {
+	return func(c *HTTPTransport) {
+		c.headers = headers
 	}
 }
 
@@ -136,6 +144,9 @@ func (c *HTTPTransport) send(spans []*j.Span) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-thrift")
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
 
 	if c.httpCredentials != nil {
 		req.SetBasicAuth(c.httpCredentials.username, c.httpCredentials.password)


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves: #478

When services, such as jaeger-collector, are deployed to production, they are assigned ephemeral IP addresses and ports when listening for HTTP requests.

In order for caller services (whether calling from development or production) to reach specific endpoints of callee services, a side-car process is used to route the outbound request to the correct IP and port which is achieved by providing the:

 - caller service name
 - target service name
 - target HTTP endpoint

Currently, jaeger-client-go does not provide a capability for clients to flexibly add headers to the outbound HTTP request.

## Short description of the changes
- Add a key-value map `Headers` to `ReporterConfig`
- This allows clients to configure custom headers which will be passed to the `NewHTTPTransport`
- These custom headers will be set in the outbound HTTP request when submitting spans
