### PR TITLE
Add limit on log records per span

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -52,6 +52,7 @@ type Tracer struct {
 		highTraceIDGenerator        func() uint64 // custom high trace ID generator
 		maxTagValueLength           int
 		noDebugFlagOnForcedSampling bool
+		maxLogsPerSpan              int
 		// more options to come
 	}
 	// allocator of Span objects

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -144,6 +144,18 @@ func (tracerOptions) MaxTagValueLength(maxTagValueLength int) TracerOption {
 	}
 }
 
+// MaxLogsPerSpan limits the number of Logs in a span (if set to a nonzero
+// value). If a span has more logs than this value, logs are dropped as
+// necessary (and replaced with a log describing how many were dropped).
+//
+// About half of the MaxLogsPerSpan logs kept are the oldest logs, and about
+// half are the newest logs.
+func (tracerOptions) MaxLogsPerSpan(maxLogsPerSpan int) TracerOption {
+	return func(tracer *Tracer) {
+		tracer.options.maxLogsPerSpan = maxLogsPerSpan
+	}
+}
+
 func (tracerOptions) ZipkinSharedRPCSpan(zipkinSharedRPCSpan bool) TracerOption {
 	return func(tracer *Tracer) {
 		tracer.options.zipkinSharedRPCSpan = zipkinSharedRPCSpan


### PR DESCRIPTION
The MaxLogsPerSpan option limits the number of logs in a Span. Events are
dropped as necessary; a log in the finished span indicates how many were
dropped.

Resolves #46

Almost copy of https://github.com/opentracing/basictracer-go/pull/39/commits/723bb40d4f3bf4fcc8d01a1805bde4bd19430502