### PR TITLE
Unset highest bit of traceID in probabilistic sampler

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -141,7 +141,7 @@ func (s *ProbabilisticSampler) SamplingRate() float64 {
 
 // IsSampled implements IsSampled() of Sampler.
 func (s *ProbabilisticSampler) IsSampled(id TraceID, operation string) (bool, []Tag) {
-	return s.samplingBoundary >= id.Low, s.tags
+	return s.samplingBoundary >= id.Low&maxRandomNumber, s.tags
 }
 
 // Close implements Close() of Sampler.

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -86,6 +86,16 @@ func TestProbabilisticSampler(t *testing.T) {
 	sampled, tags = sampler.IsSampled(TraceID{Low: testMaxID - 20}, testOperationName)
 	assert.True(t, sampled)
 	assert.Equal(t, testProbabilisticExpectedTags, tags)
+
+	t.Run("test_64bit_id", func(t *testing.T) {
+		sampled, tags := sampler.IsSampled(TraceID{Low: (testMaxID + 10) | 1<<63}, testOperationName)
+		assert.False(t, sampled)
+		assert.Equal(t, testProbabilisticExpectedTags, tags)
+		sampled, tags = sampler.IsSampled(TraceID{Low: (testMaxID - 20) | 1<<63}, testOperationName)
+		assert.True(t, sampled)
+		assert.Equal(t, testProbabilisticExpectedTags, tags)
+	})
+
 	sampler2, _ := NewProbabilisticSampler(0.5)
 	assert.True(t, sampler.Equal(sampler2))
 	assert.False(t, sampler.Equal(NewConstSampler(true)))


### PR DESCRIPTION
This commit fixes interconnection of ProbabilisticSampler.IsSampled and tracerOptions.RandomNumber:
- RandomNumber accepts `func() uint64` and doesn't documents it should return 63bit integer
- IsSampled performed check as if random number were 63bit integer.

This fix (suggested by Yuri Shkuro) truncates highest bit before comparison in IsSampled,
therefore it doesn't matter if random number is 63bit or 64bit.

fixes #489 

Signed-off-by: Sokolov Yura <funny.falcon@gmail.com>