### PR TITLE
Fix Closer() Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ defer closer.Close()
 This is especially useful for command-line tools that enable tracing, as well as
 for the long-running apps that support graceful shutdown. For example, if your deployment
 system sends SIGTERM instead of killing the process and you trap that signal to do a graceful
-exit, then having `defer closer.Closer()` ensures that all buffered spans are flushed.
+exit, then having `defer closer.Close()` ensures that all buffered spans are flushed.
 
 ### Metrics & Monitoring
 


### PR DESCRIPTION
Signed-off-by: Febrian Setianto <febrian.setianto@gmail.com>

## Which problem is this PR solving?
- Fix 1 typo in `README.md`

## Short description of the changes
- Change `defer closer.Closer()` to `defer closer.Close()`

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->