### PR TITLE
Add a debug logging interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -182,7 +182,7 @@
   revision = "2cfd321de3ee5d5f8a5fda2521d1703478334d98"
 
 [[projects]]
-  digest = "1:6be13632ab4bd5842a097abb3aabac045a8601e19a10da4239e7d8bd83d4b83c"
+  digest = "1:98a70115729234dc73ee7bb83973cb39cb8fedf278d17df77264382bad0183ec"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -191,6 +191,7 @@
     "internal/color",
     "internal/exit",
     "zapcore",
+    "zaptest/observer",
   ]
   pruneopts = "UT"
   revision = "a6015e13fab9b744d96085308ce4e8f11bad1996"
@@ -312,6 +313,7 @@
     "go.uber.org/atomic",
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
+    "go.uber.org/zap/zaptest/observer",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/log/zap/logger.go
+++ b/log/zap/logger.go
@@ -37,3 +37,10 @@ func (l *Logger) Error(msg string) {
 func (l *Logger) Infof(msg string, args ...interface{}) {
 	l.logger.Infof(msg, args...)
 }
+
+// Debugf logs a message at debug priority
+// TODO: treat the last arg specially similar to Slf4J
+// - cast to zap.Span/etc if  type assertion succeeds
+func (l *Logger) Debugf(msg string, args ...interface{}) {
+	l.logger.Debugf(msg, args...)
+}

--- a/log/zap/logger.go
+++ b/log/zap/logger.go
@@ -38,7 +38,7 @@ func (l *Logger) Infof(msg string, args ...interface{}) {
 	l.logger.Infof(msg, args...)
 }
 
-// Debugf logs a message at debug priority
+// Debugf logs a message at debug priority.
 // TODO: treat the last arg specially similar to Slf4J
 // - cast to zap.Span/etc if  type assertion succeeds
 func (l *Logger) Debugf(msg string, args ...interface{}) {

--- a/reporter_options.go
+++ b/reporter_options.go
@@ -16,6 +16,8 @@ package jaeger
 
 import (
 	"time"
+
+	"github.com/uber/jaeger-client-go/log"
 )
 
 // ReporterOption is a function that sets some option on the reporter.
@@ -31,7 +33,7 @@ type reporterOptions struct {
 	// bufferFlushInterval is how often the buffer is force-flushed, even if it's not full
 	bufferFlushInterval time.Duration
 	// logger is used to log errors of span submissions
-	logger Logger
+	logger log.DebugLogger
 	// metrics is used to record runtime stats
 	metrics *Metrics
 }
@@ -64,6 +66,6 @@ func (reporterOptions) BufferFlushInterval(bufferFlushInterval time.Duration) Re
 // errors of span submissions.
 func (reporterOptions) Logger(logger Logger) ReporterOption {
 	return func(r *reporterOptions) {
-		r.logger = logger
+		r.logger = log.DebugLogAdapter(logger)
 	}
 }

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -17,7 +17,6 @@ package jaeger
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/uber/jaeger-client-go/log"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -25,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
 )
 

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -17,6 +17,7 @@ package jaeger
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/uber/jaeger-client-go/log"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -290,7 +291,7 @@ func (u *AdaptiveSamplerUpdater) Update(sampler SamplerV2, strategy interface{})
 
 type httpSamplingStrategyFetcher struct {
 	serverURL string
-	logger    Logger
+	logger    log.DebugLogger
 }
 
 func (f *httpSamplingStrategyFetcher) Fetch(serviceName string) ([]byte, error) {

--- a/sampler_remote_options.go
+++ b/sampler_remote_options.go
@@ -35,7 +35,7 @@ type SamplerOptionsFactory struct{}
 type samplerOptions struct {
 	metrics                 *Metrics
 	sampler                 SamplerV2
-	logger                  Logger
+	logger                  log.DebugLogger
 	samplingServerURL       string
 	samplingRefreshInterval time.Duration
 	samplingFetcher         SamplingStrategyFetcher
@@ -79,7 +79,7 @@ func (SamplerOptionsFactory) InitialSampler(sampler Sampler) SamplerOption {
 // Logger creates a SamplerOption that sets the logger used by the sampler.
 func (SamplerOptionsFactory) Logger(logger Logger) SamplerOption {
 	return func(o *samplerOptions) {
-		o.logger = logger
+		o.logger = log.DebugLogAdapter(logger)
 	}
 }
 

--- a/sampler_remote_test.go
+++ b/sampler_remote_test.go
@@ -32,7 +32,7 @@ import (
 func TestRemoteSamplerOptions(t *testing.T) {
 	m := new(Metrics)
 	initSampler, _ := NewProbabilisticSampler(0.123)
-	logger := new(nullLogger)
+	logger := log.NullLogger
 	fetcher := new(fakeSamplingFetcher)
 	parser := new(samplingStrategyParser)
 	updaters := []SamplerUpdater{new(ProbabilisticSamplerUpdater)}

--- a/tracer.go
+++ b/tracer.go
@@ -41,7 +41,7 @@ type Tracer struct {
 	sampler  SamplerV2
 	reporter Reporter
 	metrics  Metrics
-	logger   log.Logger
+	logger   log.DebugLogger
 
 	timeNow      func() time.Time
 	randomNumber func() uint64

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/uber/jaeger-client-go/internal/baggage"
 	"github.com/uber/jaeger-client-go/internal/throttler"
+	"github.com/uber/jaeger-client-go/log"
 )
 
 // TracerOption is a function that sets some option on the tracer
@@ -42,7 +43,7 @@ func (tracerOptions) Metrics(m *Metrics) TracerOption {
 // Logger creates a TracerOption that gives the tracer a Logger.
 func (tracerOptions) Logger(logger Logger) TracerOption {
 	return func(tracer *Tracer) {
-		tracer.logger = logger
+		tracer.logger = log.DebugLogAdapter(logger)
 	}
 }
 


### PR DESCRIPTION
Relates to #501

- Add a debug log interface so that the client may log more details when the supplied logger supports `debug` logging and is configured to log `debug` logs. 
- Add a debug log adapter that converts a standard logger to a debug logger if it satisfies the new interface. If it doesn't, debug logging is disabled. 
