### PR TITLE
Add debug logs

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -257,6 +257,7 @@ func (r *remoteReporter) Report(span *Span) {
 
 // Close implements Close() method of Reporter by waiting for the queue to be drained.
 func (r *remoteReporter) Close() {
+	r.logger.Debugf("closing reporter")
 	if swapped := atomic.CompareAndSwapInt64(&r.closed, 0, 1); !swapped {
 		r.logger.Error("Repeated attempt to close the reporter is ignored")
 		return
@@ -307,6 +308,7 @@ func (r *remoteReporter) processQueue() {
 					r.metrics.ReporterSuccess.Inc(int64(flushed))
 					// to reduce the number of gauge stats, we only emit queue length on flush
 					r.metrics.ReporterQueueLength.Update(atomic.LoadInt64(&r.queueLength))
+					r.logger.Debugf("flushed %d spans", flushed)
 				}
 				span.Release()
 			case reporterQueueItemClose:

--- a/sampler.go
+++ b/sampler.go
@@ -17,6 +17,7 @@ package jaeger
 import (
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 
 	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
@@ -319,6 +320,10 @@ func (s *GuaranteedThroughputProbabilisticSampler) update(lowerBound, samplingRa
 	}
 }
 
+func (s GuaranteedThroughputProbabilisticSampler) String() string {
+	return fmt.Sprintf("GuaranteedThroughputProbabilisticSampler(lowerBound=%f, samplingRate=%f)", s.lowerBound, s.samplingRate)
+}
+
 // -----------------------
 
 // PerOperationSampler is a delegating sampler that applies GuaranteedThroughputProbabilisticSampler
@@ -454,6 +459,23 @@ func (s *PerOperationSampler) Close() {
 		sampler.Close()
 	}
 	s.defaultSampler.Close()
+}
+
+func (s PerOperationSampler) String() string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "PerOperationSampler(defaultSampler=%v, ", s.defaultSampler)
+	fmt.Fprintf(&sb, "lowerBound=%f, ", s.lowerBound)
+	fmt.Fprintf(&sb, "maxOperations=%d, ", s.maxOperations)
+	fmt.Fprintf(&sb, "operationNameLateBinding=%t, ", s.operationNameLateBinding)
+	fmt.Fprintf(&sb, "currentOperationSize=%d,\n", len(s.samplers))
+	fmt.Fprintf(&sb, "samplers=[")
+	for operationName, sampler := range s.samplers {
+		fmt.Fprintf(&sb, "\n(operationName=%s, sampler=%v)", operationName, sampler)
+	}
+	fmt.Fprintf(&sb, "])")
+
+	return sb.String()
 }
 
 // Equal is not used.

--- a/sampler.go
+++ b/sampler.go
@@ -461,7 +461,7 @@ func (s *PerOperationSampler) Close() {
 	s.defaultSampler.Close()
 }
 
-func (s PerOperationSampler) String() string {
+func (s *PerOperationSampler) String() string {
 	var sb strings.Builder
 
 	fmt.Fprintf(&sb, "PerOperationSampler(defaultSampler=%v, ", s.defaultSampler)

--- a/sampler.go
+++ b/sampler.go
@@ -468,7 +468,7 @@ func (s PerOperationSampler) String() string {
 	fmt.Fprintf(&sb, "lowerBound=%f, ", s.lowerBound)
 	fmt.Fprintf(&sb, "maxOperations=%d, ", s.maxOperations)
 	fmt.Fprintf(&sb, "operationNameLateBinding=%t, ", s.operationNameLateBinding)
-	fmt.Fprintf(&sb, "currentOperationSize=%d,\n", len(s.samplers))
+	fmt.Fprintf(&sb, "numOperations=%d,\n", len(s.samplers))
 	fmt.Fprintf(&sb, "samplers=[")
 	for operationName, sampler := range s.samplers {
 		fmt.Fprintf(&sb, "\n(operationName=%s, sampler=%v)", operationName, sampler)

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -200,6 +200,7 @@ func (s *RemotelyControlledSampler) updateSamplerViaUpdaters(strategy interface{
 			return err
 		}
 		if sampler != nil {
+			s.logger.Debugf("sampler updated: %+v", sampler)
 			s.sampler = sampler
 			return nil
 		}

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -232,10 +232,10 @@ func TestPerOperationSampler_String(t *testing.T) {
 	})
 
 	assert.Equal(t,
-		"PerOperationSampler(defaultSampler=ProbabilisticSampler(samplingRate=0.5), lowerBound=2.000000, " +
-		"maxOperations=10, operationNameLateBinding=false, numOperations=1,\nsamplers=[\n" +
-		"(operationName=op, " +
-		"sampler=GuaranteedThroughputProbabilisticSampler(lowerBound=2.000000, samplingRate=1.000000))])",
+		"PerOperationSampler(defaultSampler=ProbabilisticSampler(samplingRate=0.5), lowerBound=2.000000, "+
+			"maxOperations=10, operationNameLateBinding=false, numOperations=1,\nsamplers=[\n"+
+			"(operationName=op, "+
+			"sampler=GuaranteedThroughputProbabilisticSampler(lowerBound=2.000000, samplingRate=1.000000))])",
 		sampler.String())
 }
 

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -214,6 +214,31 @@ func TestAdaptiveSampler(t *testing.T) {
 	assert.False(t, decision.Sample)
 }
 
+func TestPerOperationSampler_String(t *testing.T) {
+	strategies := &sampling.PerOperationSamplingStrategies{
+		DefaultSamplingProbability:       testDefaultSamplingProbability,
+		DefaultLowerBoundTracesPerSecond: 2.0,
+		PerOperationStrategies: []*sampling.OperationSamplingStrategy{
+			{
+				Operation:             testOperationName,
+				ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{SamplingRate: 1},
+			},
+		},
+	}
+
+	sampler := NewPerOperationSampler(PerOperationSamplerParams{
+		MaxOperations: testDefaultMaxOperations,
+		Strategies:    strategies,
+	})
+
+	assert.Equal(t,
+		"PerOperationSampler(defaultSampler=ProbabilisticSampler(samplingRate=0.5), lowerBound=2.000000, " +
+		"maxOperations=10, operationNameLateBinding=false, numOperations=1,\nsamplers=[\n" +
+		"(operationName=op, " +
+		"sampler=GuaranteedThroughputProbabilisticSampler(lowerBound=2.000000, samplingRate=1.000000))])",
+		sampler.String())
+}
+
 func TestAdaptiveSamplerErrors(t *testing.T) {
 	strategies := &sampling.PerOperationSamplingStrategies{
 		DefaultSamplingProbability:       testDefaultSamplingProbability,

--- a/tracer.go
+++ b/tracer.go
@@ -366,6 +366,7 @@ func (t *Tracer) Extract(
 
 // Close releases all resources used by the Tracer and flushes any remaining buffered spans.
 func (t *Tracer) Close() error {
+	t.logger.Debugf("closing tracer")
 	t.reporter.Close()
 	t.sampler.Close()
 	if mgr, ok := t.baggageRestrictionManager.(io.Closer); ok {


### PR DESCRIPTION
Part of #501

- Log tracer and reporter closes
- Log samplers on updates to sampling strategies. By default, these happen once a minute

Signed-off-by: Prithvi Raj <p.r@uber.com>

