### PR TITLE
Fix regression by handling nil logger correctly

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -114,14 +114,14 @@ type DebugLogger interface {
 // If the provided Logger doesn't satisfy the interface, a logger with debug
 // disabled is returned
 func DebugLogAdapter(logger Logger) DebugLogger {
+	if logger == nil {
+		return nil
+	}
 	if debugLogger, ok := logger.(DebugLogger); ok {
 		return debugLogger
 	}
-	if logger != nil {
-		logger.Infof("debug logging disabled")
-		return debugDisabledLogAdapter{logger: logger}
-	}
-	return nil
+	logger.Infof("debug logging disabled")
+	return debugDisabledLogAdapter{logger: logger}
 }
 
 type debugDisabledLogAdapter struct {

--- a/log/logger.go
+++ b/log/logger.go
@@ -111,14 +111,17 @@ type DebugLogger interface {
 }
 
 // DebugLogAdapter is a log adapter that converts a Logger into a DebugLogger
-// If the provided Logger doesn't satisfy the interface, a logger with debug
+// If the provided Logger is nil or doesn't satisfy the interface, a logger with debug
 // disabled is returned
 func DebugLogAdapter(logger Logger) DebugLogger {
 	if debugLogger, ok := logger.(DebugLogger); ok {
 		return debugLogger
 	}
-	logger.Infof("debug logging disabled")
-	return debugDisabledLogAdapter{logger: logger}
+	if logger != nil {
+		logger.Infof("debug logging disabled")
+		return debugDisabledLogAdapter{logger: logger}
+	}
+	return nil
 }
 
 type debugDisabledLogAdapter struct {

--- a/log/logger.go
+++ b/log/logger.go
@@ -111,7 +111,7 @@ type DebugLogger interface {
 }
 
 // DebugLogAdapter is a log adapter that converts a Logger into a DebugLogger
-// If the provided Logger is nil or doesn't satisfy the interface, a logger with debug
+// If the provided Logger doesn't satisfy the interface, a logger with debug
 // disabled is returned
 func DebugLogAdapter(logger Logger) DebugLogger {
 	if debugLogger, ok := logger.(DebugLogger); ok {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -36,6 +36,10 @@ func TestDebugLogAdapter_ReturnSameIfDebugLogger(t *testing.T) {
 	assert.Same(t, NullLogger, DebugLogAdapter(NullLogger))
 }
 
+func TestDebugLogAdapter_HandleNil(t *testing.T) {
+	assert.Nil(t, DebugLogAdapter(nil))
+}
+
 type mockLogger struct {
 	errorCalled bool
 	infoCalled  bool


### PR DESCRIPTION
- Jaeger components may be initialized with `nil` loggers. 
- Verify that the logger is non-nil before logging in the `DebugLoggingAdaptor` to preserve old behavior

Signed-off-by: Prithvi Raj <p.r@uber.com>