### PR TITLE
override reporter config only when agent host or port was set in env

### DIFF
--- a/config/config_env.go
+++ b/config/config_env.go
@@ -187,20 +187,25 @@ func (rc *ReporterConfig) reporterConfigFromEnv() (*ReporterConfig, error) {
 		rc.User = user
 		rc.Password = pswd
 	} else {
+		useEnv := false
 		host := jaeger.DefaultUDPSpanServerHost
 		if e := os.Getenv(envAgentHost); e != "" {
 			host = e
+			useEnv = true
 		}
 
 		port := jaeger.DefaultUDPSpanServerPort
 		if e := os.Getenv(envAgentPort); e != "" {
 			if value, err := strconv.ParseInt(e, 10, 0); err == nil {
 				port = int(value)
+				useEnv = true
 			} else {
 				return nil, errors.Wrapf(err, "cannot parse env var %s=%s", envAgentPort, e)
 			}
 		}
-		rc.LocalAgentHostPort = fmt.Sprintf("%s:%d", host, port)
+		if useEnv || rc.LocalAgentHostPort == "" {
+			rc.LocalAgentHostPort = fmt.Sprintf("%s:%d", host, port)
+		}
 	}
 
 	return rc, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -252,6 +252,57 @@ func TestReporter(t *testing.T) {
 	assert.Equal(t, "user", cfg.User)
 	assert.Equal(t, "password", cfg.Password)
 
+	//
+	unsetEnv(t, envEndpoint)
+	unsetEnv(t, envAgentHost)
+	unsetEnv(t, envAgentPort)
+
+	rc = ReporterConfig{
+	}
+
+	//
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "localhost:6831", cfg.LocalAgentHostPort)
+
+	//
+	rc = ReporterConfig{
+		LocalAgentHostPort: "localhost01:7777",
+	}
+
+	//
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "localhost01:7777", cfg.LocalAgentHostPort)
+
+	//
+	setEnv(t, envAgentHost, "localhost02")
+	unsetEnv(t, envAgentPort)
+	rc = ReporterConfig{
+		LocalAgentHostPort: "localhost01:7777",
+	}
+
+	//
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "localhost02:6831", cfg.LocalAgentHostPort)
+
+	//
+	unsetEnv(t, envAgentHost)
+	setEnv(t, envAgentPort, "8888")
+	rc = ReporterConfig{
+		LocalAgentHostPort: "localhost01:7777",
+	}
+
+	//
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "localhost:8888", cfg.LocalAgentHostPort)
+
 	// cleanup
 	unsetEnv(t, envReporterMaxQueueSize)
 	unsetEnv(t, envReporterFlushInterval)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -256,9 +256,7 @@ func TestReporter(t *testing.T) {
 	unsetEnv(t, envEndpoint)
 	unsetEnv(t, envAgentHost)
 	unsetEnv(t, envAgentPort)
-
-	rc = ReporterConfig{
-	}
+	rc = ReporterConfig{}
 
 	//
 	cfg, err = rc.reporterConfigFromEnv()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -252,55 +252,6 @@ func TestReporter(t *testing.T) {
 	assert.Equal(t, "user", cfg.User)
 	assert.Equal(t, "password", cfg.Password)
 
-	//
-	unsetEnv(t, envEndpoint)
-	unsetEnv(t, envAgentHost)
-	unsetEnv(t, envAgentPort)
-	rc = ReporterConfig{}
-
-	//
-	cfg, err = rc.reporterConfigFromEnv()
-	assert.NoError(t, err)
-
-	assert.Equal(t, "localhost:6831", cfg.LocalAgentHostPort)
-
-	//
-	rc = ReporterConfig{
-		LocalAgentHostPort: "localhost01:7777",
-	}
-
-	//
-	cfg, err = rc.reporterConfigFromEnv()
-	assert.NoError(t, err)
-
-	assert.Equal(t, "localhost01:7777", cfg.LocalAgentHostPort)
-
-	//
-	setEnv(t, envAgentHost, "localhost02")
-	unsetEnv(t, envAgentPort)
-	rc = ReporterConfig{
-		LocalAgentHostPort: "localhost01:7777",
-	}
-
-	//
-	cfg, err = rc.reporterConfigFromEnv()
-	assert.NoError(t, err)
-
-	assert.Equal(t, "localhost02:6831", cfg.LocalAgentHostPort)
-
-	//
-	unsetEnv(t, envAgentHost)
-	setEnv(t, envAgentPort, "8888")
-	rc = ReporterConfig{
-		LocalAgentHostPort: "localhost01:7777",
-	}
-
-	//
-	cfg, err = rc.reporterConfigFromEnv()
-	assert.NoError(t, err)
-
-	assert.Equal(t, "localhost:8888", cfg.LocalAgentHostPort)
-
 	// cleanup
 	unsetEnv(t, envReporterMaxQueueSize)
 	unsetEnv(t, envReporterFlushInterval)
@@ -445,6 +396,68 @@ func TestReporterConfigFromEnv(t *testing.T) {
 	unsetEnv(t, envEndpoint)
 	unsetEnv(t, envUser)
 	unsetEnv(t, envPassword)
+}
+
+func TestReporterAgentConfigFromEnv(t *testing.T) {
+	// prepare
+	unsetEnv(t, envEndpoint)
+	unsetEnv(t, envAgentHost)
+	unsetEnv(t, envAgentPort)
+
+	// No config and no env check
+	rc := ReporterConfig{}
+
+	// test
+	cfg, err := rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "localhost:6831", cfg.LocalAgentHostPort)
+
+	// No env check
+	rc = ReporterConfig{
+		LocalAgentHostPort: "localhost01:7777",
+	}
+
+	// test
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "localhost01:7777", cfg.LocalAgentHostPort)
+
+	// Only host env check
+	setEnv(t, envAgentHost, "localhost02")
+	unsetEnv(t, envAgentPort)
+	rc = ReporterConfig{
+		LocalAgentHostPort: "localhost01:7777",
+	}
+
+	// test
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "localhost02:6831", cfg.LocalAgentHostPort)
+
+	// Only port env check
+	unsetEnv(t, envAgentHost)
+	setEnv(t, envAgentPort, "8888")
+	rc = ReporterConfig{
+		LocalAgentHostPort: "localhost01:7777",
+	}
+
+	// test
+	cfg, err = rc.reporterConfigFromEnv()
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "localhost:8888", cfg.LocalAgentHostPort)
+
+	// cleanup
+	unsetEnv(t, envEndpoint)
+	unsetEnv(t, envAgentHost)
+	unsetEnv(t, envAgentPort)
 }
 
 func TestParsingErrorsFromEnv(t *testing.T) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #473 
- Supersedes / Closes #474 

## Short description of the changes
- In `ReporterConfig.reporterConfigFromEnv()`, override reporter agent config only when agent host or port was set in env.
