### PR TITLE
Do not add invalid context to references

### DIFF
--- a/span_context.go
+++ b/span_context.go
@@ -212,10 +212,14 @@ func (c SpanContext) SetFirehose() {
 }
 
 func (c SpanContext) String() string {
-	if c.traceID.High == 0 {
-		return fmt.Sprintf("%016x:%016x:%016x:%x", c.traceID.Low, uint64(c.spanID), uint64(c.parentID), c.samplingState.stateFlags.Load())
+	var flags int32
+	if c.samplingState != nil {
+		flags = c.samplingState.stateFlags.Load()
 	}
-	return fmt.Sprintf("%016x%016x:%016x:%016x:%x", c.traceID.High, c.traceID.Low, uint64(c.spanID), uint64(c.parentID), c.samplingState.stateFlags.Load())
+	if c.traceID.High == 0 {
+		return fmt.Sprintf("%016x:%016x:%016x:%x", c.traceID.Low, uint64(c.spanID), uint64(c.parentID), flags)
+	}
+	return fmt.Sprintf("%016x%016x:%016x:%016x:%x", c.traceID.High, c.traceID.Low, uint64(c.spanID), uint64(c.parentID), flags)
 }
 
 // ContextFromString reconstructs the Context encoded in a string

--- a/tracer.go
+++ b/tracer.go
@@ -245,7 +245,10 @@ func (t *Tracer) startSpanWithOptions(
 			continue
 		}
 
-		references = append(references, Reference{Type: ref.Type, Context: ctxRef})
+		if ctxRef.IsValid() {
+			// we don't want empty context that contains only debug-id or baggage
+			references = append(references, Reference{Type: ref.Type, Context: ctxRef})
+		}
 
 		if !hasParent {
 			parent = ctxRef

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -414,6 +414,7 @@ func TestThrottling_DebugHeader(t *testing.T) {
 
 	sp := tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*Span)
 	assert.True(t, sp.context.IsDebug())
+	assert.Len(t, sp.References(), 0)
 	closer.Close()
 
 	tracer, closer = NewTracer("DOOP", NewConstSampler(true), NewNullReporter(),


### PR DESCRIPTION
## Which problem is this PR solving?
- when sending requests with `jaeger-debug-id` header, the root span gets an invalid parent reference resulting in a warning

![image](https://user-images.githubusercontent.com/3523016/87339582-d3b39180-c514-11ea-8fdc-ab26f77ef46b.png)

## Short description of the changes
- do not add span context to references if it does not contain valid trace ID
- fix null pointer error in `SpanContext.String()`
