### PR TITLE
Upgrade to OpenTracing Go 1.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,7 +70,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:727b8f567a30d0739d6c26b9472b3422b351c93cf62095164c845a54b16fc18e"
+  digest = "1:fe5217d44ae8fb84f711968816fe50077cea9dfa8f44425b8e44e7e3de896d01"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -79,8 +79,8 @@
     "log",
   ]
   pruneopts = "UT"
-  revision = "659c90643e714681897ec2521c60567dd21da733"
-  version = "v1.1.0"
+  revision = "d34af3eaa63c4d08ab54863a4bdd0daa45212e12"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
@@ -161,42 +161,6 @@
   pruneopts = "UT"
   revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
   version = "v1.4.0"
-
-[[projects]]
-  digest = "1:5b98956718573850caf7e0fd00b571a6657c4ef1f345ddf0c96b43ce355fe862"
-  name = "github.com/uber/jaeger-client-go"
-  packages = [
-    ".",
-    "config",
-    "crossdock/client",
-    "crossdock/common",
-    "crossdock/endtoend",
-    "crossdock/log",
-    "crossdock/server",
-    "crossdock/thrift/tracetest",
-    "internal/baggage",
-    "internal/baggage/remote",
-    "internal/reporterstats",
-    "internal/spanlog",
-    "internal/throttler",
-    "internal/throttler/remote",
-    "log",
-    "log/zap/mock_opentracing",
-    "rpcmetrics",
-    "testutils",
-    "thrift",
-    "thrift-gen/agent",
-    "thrift-gen/baggage",
-    "thrift-gen/jaeger",
-    "thrift-gen/sampling",
-    "thrift-gen/zipkincore",
-    "transport",
-    "transport/zipkin",
-    "utils",
-  ]
-  pruneopts = "UT"
-  revision = "66c008c3d6ad856cac92a0af53186efbffa8e6a5"
-  version = "v2.24.0"
 
 [[projects]]
   digest = "1:0ec60ffd594af00ba1660bc746aa0e443d27dd4003dee55f9d08a0b4ff5431a3"
@@ -362,33 +326,6 @@
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
-    "github.com/uber/jaeger-client-go",
-    "github.com/uber/jaeger-client-go/config",
-    "github.com/uber/jaeger-client-go/crossdock/client",
-    "github.com/uber/jaeger-client-go/crossdock/common",
-    "github.com/uber/jaeger-client-go/crossdock/endtoend",
-    "github.com/uber/jaeger-client-go/crossdock/log",
-    "github.com/uber/jaeger-client-go/crossdock/server",
-    "github.com/uber/jaeger-client-go/crossdock/thrift/tracetest",
-    "github.com/uber/jaeger-client-go/internal/baggage",
-    "github.com/uber/jaeger-client-go/internal/baggage/remote",
-    "github.com/uber/jaeger-client-go/internal/reporterstats",
-    "github.com/uber/jaeger-client-go/internal/spanlog",
-    "github.com/uber/jaeger-client-go/internal/throttler",
-    "github.com/uber/jaeger-client-go/internal/throttler/remote",
-    "github.com/uber/jaeger-client-go/log",
-    "github.com/uber/jaeger-client-go/log/zap/mock_opentracing",
-    "github.com/uber/jaeger-client-go/rpcmetrics",
-    "github.com/uber/jaeger-client-go/testutils",
-    "github.com/uber/jaeger-client-go/thrift",
-    "github.com/uber/jaeger-client-go/thrift-gen/agent",
-    "github.com/uber/jaeger-client-go/thrift-gen/baggage",
-    "github.com/uber/jaeger-client-go/thrift-gen/jaeger",
-    "github.com/uber/jaeger-client-go/thrift-gen/sampling",
-    "github.com/uber/jaeger-client-go/thrift-gen/zipkincore",
-    "github.com/uber/jaeger-client-go/transport",
-    "github.com/uber/jaeger-client-go/transport/zipkin",
-    "github.com/uber/jaeger-client-go/utils",
     "github.com/uber/jaeger-lib/metrics",
     "github.com/uber/jaeger-lib/metrics/metricstest",
     "github.com/uber/jaeger-lib/metrics/prometheus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/opentracing/opentracing-go"
-  version = "^1.1"
+  version = "^1.2"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: a4a449cfc060c2d7be850a69b171e4382a3bd00d1a0a72cfc944facc3fe263bf
-updated: 2019-09-23T17:10:15.213856-04:00
+hash: a7f13588355a52af38582275dd07af1a606bb1c23b757a5520fbca50564cca5b
+updated: 2020-07-31T12:41:17.908408-04:00
 imports:
 - name: github.com/beorn7/perks
-  version: 37c8de3658fcb183f997c4e13e8337516ab753e6
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/codahale/hdrhistogram
@@ -13,11 +13,15 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
+- name: github.com/golang/mock
+  version: 51421b967af1f557f93a59e0057aaf15ca02e29c
+  subpackages:
+  - gomock
 - name: github.com/golang/protobuf
-  version: 1680a479a2cfb3fa22b972af7e36d0a0fde47bf8
+  version: b5d812f8a3706043e23a9cd5babf2e5423744d30
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -25,7 +29,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/opentracing/opentracing-go
-  version: 659c90643e714681897ec2521c60567dd21da733
+  version: d34af3eaa63c4d08ab54863a4bdd0daa45212e12
   subpackages:
   - ext
   - harness
@@ -42,28 +46,31 @@ imports:
   - prometheus
   - prometheus/internal
 - name: github.com/prometheus/client_model
-  version: 14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016
+  version: fd36f4220a901265f90734c3183c5f0c91daa0b8
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 287d3e634a1e550c9e463dd7e5a75a422c614505
+  version: 1ab4d74fc89940cfbc3c2b3a89821336cdefa119
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: de25ac347ef9305868b04dc42425c973b863b18c
+  version: 40f3c57fb1983891f95378042bd0bfd590f52384
   subpackages:
-  - internal/fs
   - internal/util
+  - iostats
+  - nfs
+  - xfs
 - name: github.com/stretchr/testify
-  version: 85f2b59c4459e5bf57488796be8c3667cb8246d6
+  version: f654a9112bbeac49ca2cd45bfbe11533c4666cf8
   subpackages:
   - assert
+  - mock
   - require
   - suite
 - name: github.com/uber-go/atomic
-  version: df976f2515e274675050de7b3f42545de80594fd
+  version: 845920076a298bdb984fb0f1b86052e4ca0a281c
 - name: github.com/uber/jaeger-lib
   version: a87ae9d84fb038a8d79266298970720be7c80fcd
   subpackages:
@@ -71,28 +78,30 @@ imports:
   - metrics/metricstest
   - metrics/prometheus
 - name: go.uber.org/atomic
-  version: df976f2515e274675050de7b3f42545de80594fd
+  version: 845920076a298bdb984fb0f1b86052e4ca0a281c
 - name: go.uber.org/multierr
-  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
+  version: b587143a48b62b01d337824eab43700af6ffe222
 - name: go.uber.org/zap
-  version: 27376062155ad36be76b0f12cf1572a221d3a48c
+  version: feeb9a050b31b40eec6f2470e7599eeeadfe5bdd
   subpackages:
   - buffer
   - internal/bufferpool
   - internal/color
   - internal/exit
   - zapcore
+  - zaptest/observer
 - name: golang.org/x/net
-  version: aa69164e4478b84860dc6769c710c699c67058a3
+  version: addf6b3196f61cd44ce5a76657913698c73479d0
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: 0a153f010e6963173baba2306531d173aa843137
+  version: 3e129f6d46b10b0e1da36b3deffcb55e09631b64
   subpackages:
+  - internal/unsafeheader
   - windows
-- name: gopkg.in/yaml.v2
-  version: 51d6538a90f86fe93ac480b35f37b2be17fef232
-- name: github.com/golang/mock 
-  version: 3a35fb6e3e18b9dbfee291262260dee7372d2a92
-testImports: []
+- name: gopkg.in/yaml.v3
+  version: eeeca48fe7764f320e4870d231902bf9c1be2c08
+testImports:
+- name: github.com/stretchr/objx
+  version: 35313a95ee26395aa17d366c71a2ccf788fa69b6

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a7f13588355a52af38582275dd07af1a606bb1c23b757a5520fbca50564cca5b
-updated: 2020-07-31T12:41:17.908408-04:00
+hash: 63bec420a22b7e5abac8c602c5cc9b66a33d6a1bfec8918eecc77fd344b759ed
+updated: 2020-07-31T13:30:37.242608-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -56,12 +56,10 @@ imports:
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 40f3c57fb1983891f95378042bd0bfd590f52384
+  version: 8a055596020d692cf491851e47ba3e302d9f90ce
   subpackages:
+  - internal/fs
   - internal/util
-  - iostats
-  - nfs
-  - xfs
 - name: github.com/stretchr/testify
   version: f654a9112bbeac49ca2cd45bfbe11533c4666cf8
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/uber/jaeger-client-go
 import:
 - package: github.com/opentracing/opentracing-go
-  version: ^1.1
+  version: ^1.2
   subpackages:
   - ext
   - log
@@ -18,7 +18,7 @@ import:
 - package: github.com/uber-go/atomic
   version: ^1
 - package: github.com/prometheus/client_golang
-  version: ^1
+  version: 1.1
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,6 +19,8 @@ import:
   version: ^1
 - package: github.com/prometheus/client_golang
   version: 1.1
+- package: github.com/prometheus/procfs
+  version: 0.0.6
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/jaeger_thrift_span_test.go
+++ b/jaeger_thrift_span_test.go
@@ -126,7 +126,7 @@ func TestBuildLogs(t *testing.T) {
 		{field: log.Uint64("k", 123), expected: []*j.Tag{{Key: "k", VType: j.TagType_LONG, VLong: &someLong}}},
 		{field: log.Float32("k", 123), expected: []*j.Tag{{Key: "k", VType: j.TagType_DOUBLE, VDouble: &someDouble}}},
 		{field: log.Float64("k", 123), expected: []*j.Tag{{Key: "k", VType: j.TagType_DOUBLE, VDouble: &someDouble}}},
-		{field: log.Error(errors.New(errString)), expected: []*j.Tag{{Key: "error", VType: j.TagType_STRING, VStr: &errString}}},
+		{field: log.Error(errors.New(errString)), expected: []*j.Tag{{Key: "error.object", VType: j.TagType_STRING, VStr: &errString}}},
 		{field: log.Object("k", someSlice), expected: []*j.Tag{{Key: "k", VType: j.TagType_STRING, VStr: &someSliceString}}},
 		{
 			field: log.Lazy(func(fv log.Encoder) {
@@ -146,7 +146,7 @@ func TestBuildLogs(t *testing.T) {
 			},
 			// this is a bit fragile, but ¯\_(ツ)_/¯
 			expected: []*j.Tag{
-				{Key: "error", VType: j.TagType_STRING, VStr: getStringPtr("non-even keyValues len: 1")},
+				{Key: "error.object", VType: j.TagType_STRING, VStr: getStringPtr("non-even keyValues len: 1")},
 				{Key: "function", VType: j.TagType_STRING, VStr: getStringPtr("LogKV")},
 			},
 		},
@@ -403,7 +403,8 @@ func compareTags(t *testing.T, expected, actual *j.Tag, testName string) {
 		return
 	}
 	if expected == nil || actual == nil {
-		assert.Fail(t, "one of the tags is nil", testName)
+		t.Logf("one of the tags is nil, test=%s, expected=%v, actual=%v", testName, expected, actual)
+		assert.Fail(t, "one of the tags is nil")
 		return
 	}
 	assert.Equal(t, expected.Key, actual.Key, testName)

--- a/zipkin_thrift_span_test.go
+++ b/zipkin_thrift_span_test.go
@@ -142,7 +142,7 @@ func TestThriftSpanLogs(t *testing.T) {
 		{fields: fields(log.Float32("something", 123)), expected: `{"something":"123.000000"}`},
 		{fields: fields(log.Float64("something", 123)), expected: `{"something":"123.000000"}`},
 		{fields: fields(log.Error(errors.New("drugs are baaad, m-k"))),
-			expected: `{"error":"drugs are baaad, m-k"}`},
+			expected: `{"error.object":"drugs are baaad, m-k"}`},
 		{fields: fields(log.Object("something", 123)), expected: `{"something":"123"}`},
 		{
 			fields: fields(log.Lazy(func(fv log.Encoder) {
@@ -161,7 +161,7 @@ func TestThriftSpanLogs(t *testing.T) {
 				sp.LogKV("non-even number of arguments")
 			},
 			// this is a bit fragile, but ¯\_(ツ)_/¯
-			expected: `{"error":"non-even keyValues len: 1","function":"LogKV"}`,
+			expected: `{"error.object":"non-even keyValues len: 1","function":"LogKV"}`,
 		},
 		{
 			logFunc: func(sp opentracing.Span) {


### PR DESCRIPTION
* Resolves #524 
* Upgrades opentracing-go dependency to 1.2 (https://github.com/opentracing/opentracing-go/releases/tag/v1.2.0)
* Pin some Prometheus client libs in glide.yaml because some of their dependencies moved to go modules with v2, which is not supported by glide.