### PR TITLE
TraceID.String prefix with zeroes

### DIFF
--- a/span_context.go
+++ b/span_context.go
@@ -344,9 +344,9 @@ func (c *SpanContext) isDebugIDContainerOnly() bool {
 
 func (t TraceID) String() string {
 	if t.High == 0 {
-		return fmt.Sprintf("%x", t.Low)
+		return fmt.Sprintf("%016x", t.Low)
 	}
-	return fmt.Sprintf("%x%016x", t.High, t.Low)
+	return fmt.Sprintf("%016x%016x", t.High, t.Low)
 }
 
 // TraceIDFromString creates a TraceID from a hexadecimal string

--- a/span_context.go
+++ b/span_context.go
@@ -379,7 +379,7 @@ func (t TraceID) IsValid() bool {
 // ------- SpanID -------
 
 func (s SpanID) String() string {
-	return fmt.Sprintf("%x", uint64(s))
+	return fmt.Sprintf("%016x", uint64(s))
 }
 
 // SpanIDFromString creates a SpanID from a hexadecimal string

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -64,9 +64,9 @@ func TestContextFromString(t *testing.T) {
 	assert.EqualValues(t, 1, ctx.spanID)
 	assert.EqualValues(t, 1, ctx.parentID)
 	assert.True(t, ctx.IsSampled())
-	assert.Equal(t, "ff", SpanID(255).String())
-	assert.Equal(t, "ff", TraceID{Low: 255}.String())
-	assert.Equal(t, "ff00000000000000ff", TraceID{High: 255, Low: 255}.String())
+	assert.Equal(t, "00000000000000ff", SpanID(255).String())
+	assert.Equal(t, "00000000000000ff", TraceID{Low: 255}.String())
+	assert.Equal(t, "00000000000000ff00000000000000ff", TraceID{High: 255, Low: 255}.String())
 	ctx = NewSpanContext(TraceID{High: 255, Low: 255}, SpanID(1), SpanID(1), false, nil)
 	assert.Equal(t, "00000000000000ff00000000000000ff:0000000000000001:0000000000000001:0", ctx.String())
 }

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -189,6 +189,33 @@ func TestTraceIDString(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.in.String())
+			parsed, err := TraceIDFromString(tc.in.String())
+			assert.NoError(t, err)
+			assert.Equal(t, tc.in, parsed)
+		})
+	}
+}
+
+func TestSpanIDString(t *testing.T) {
+	var tests = map[string]struct {
+		in       SpanID
+		expected string
+	}{
+		"SpanID zero": {
+			in:       0,
+			expected: "0000000000000000",
+		},
+		"SpanID non zero": {
+			in:       math.MaxUint64/16 - 405,
+			expected: "0ffffffffffffe6a",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.in.String())
+			parsed, err := SpanIDFromString(tc.in.String())
+			assert.NoError(t, err)
+			assert.Equal(t, tc.in, parsed)
 		})
 	}
 }

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -15,6 +15,7 @@
 package jaeger
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -165,4 +166,29 @@ func TestSpanContext_CopyFrom(t *testing.T) {
 	ctx2.CopyFrom(&ctx)
 	assert.Equal(t, ctx, ctx2)
 	assert.Equal(t, "y", ctx2.baggage["x"])
+}
+
+func TestTraceIDString(t *testing.T) {
+	var tests = map[string]struct {
+		in       TraceID
+		expected string
+	}{
+		"Empty TraceID": {
+			in:       TraceID{},
+			expected: "0000000000000000",
+		},
+		"TraceID low only": {
+			in:       TraceID{Low: math.MaxUint64/16 - 405},
+			expected: "0ffffffffffffe6a",
+		},
+		"TraceID low and high": {
+			in:       TraceID{High: math.MaxUint64 / 16, Low: math.MaxUint64/16 - 405},
+			expected: "0fffffffffffffff0ffffffffffffe6a",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.in.String())
+		})
+	}
 }

--- a/zipkin/propagation_test.go
+++ b/zipkin/propagation_test.go
@@ -32,33 +32,33 @@ var (
 
 var (
 	rootSampledHeader = opentracing.TextMapCarrier{
-		"x-b3-traceid": "1",
-		"x-b3-spanid":  "2",
-		"x-b3-sampled": "1",
+		"x-b3-traceid": "0000000000000001",
+		"x-b3-spanid":  "0000000000000002",
+		"x-b3-sampled": "0000000000000001",
 		"baggage-foo":  "bar",
 	}
 	nonRootSampledHeader = opentracing.TextMapCarrier{
-		"x-b3-traceid":      "1",
-		"x-b3-spanid":       "2",
-		"x-b3-parentspanid": "1",
+		"x-b3-traceid":      "0000000000000001",
+		"x-b3-spanid":       "0000000000000002",
+		"x-b3-parentspanid": "0000000000000001",
 		"x-b3-sampled":      "1",
 	}
 	nonRootNonSampledHeader = opentracing.TextMapCarrier{
-		"x-b3-traceid":      "1",
-		"x-b3-spanid":       "2",
-		"x-b3-parentspanid": "1",
+		"x-b3-traceid":      "0000000000000001",
+		"x-b3-spanid":       "0000000000000002",
+		"x-b3-parentspanid": "0000000000000001",
 		"x-b3-sampled":      "0",
 	}
 	rootSampledBooleanHeader = opentracing.TextMapCarrier{
-		"x-b3-traceid": "1",
-		"x-b3-spanid":  "2",
+		"x-b3-traceid": "0000000000000001",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "true",
 		"baggage-foo":  "bar",
 	}
 	nonRootSampledBooleanHeader = opentracing.TextMapCarrier{
-		"x-b3-traceid":      "1",
-		"x-b3-spanid":       "2",
-		"x-b3-parentspanid": "1",
+		"x-b3-traceid":      "0000000000000001",
+		"x-b3-spanid":       "0000000000000002",
+		"x-b3-parentspanid": "0000000000000001",
 		"x-b3-sampled":      "true",
 	}
 	invalidHeader = opentracing.TextMapCarrier{
@@ -69,12 +69,12 @@ var (
 	}
 	sampled128bitTraceID = opentracing.TextMapCarrier{
 		"x-b3-traceid": "463ac35c9f6413ad48485a3953bb6124",
-		"x-b3-spanid":  "2",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "1",
 	}
 	invalidTraceID = opentracing.TextMapCarrier{
 		"x-b3-traceid": "00000000000000000000000000000000",
-		"x-b3-spanid":  "2",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "1",
 	}
 )

--- a/zipkin/propagation_test.go
+++ b/zipkin/propagation_test.go
@@ -33,32 +33,32 @@ var (
 var (
 	rootSampledHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid": "0000000000000001",
-		"x-b3-spanid":  "0000000000000002",
-		"x-b3-sampled": "0000000000000001",
+		"x-b3-spanid":  "2",
+		"x-b3-sampled": "1",
 		"baggage-foo":  "bar",
 	}
 	nonRootSampledHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid":      "0000000000000001",
-		"x-b3-spanid":       "0000000000000002",
-		"x-b3-parentspanid": "0000000000000001",
+		"x-b3-spanid":       "2",
+		"x-b3-parentspanid": "1",
 		"x-b3-sampled":      "1",
 	}
 	nonRootNonSampledHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid":      "0000000000000001",
-		"x-b3-spanid":       "0000000000000002",
-		"x-b3-parentspanid": "0000000000000001",
+		"x-b3-spanid":       "2",
+		"x-b3-parentspanid": "1",
 		"x-b3-sampled":      "0",
 	}
 	rootSampledBooleanHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid": "0000000000000001",
-		"x-b3-spanid":  "0000000000000002",
+		"x-b3-spanid":  "2",
 		"x-b3-sampled": "true",
 		"baggage-foo":  "bar",
 	}
 	nonRootSampledBooleanHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid":      "0000000000000001",
-		"x-b3-spanid":       "0000000000000002",
-		"x-b3-parentspanid": "0000000000000001",
+		"x-b3-spanid":       "2",
+		"x-b3-parentspanid": "1",
 		"x-b3-sampled":      "true",
 	}
 	invalidHeader = opentracing.TextMapCarrier{
@@ -69,12 +69,12 @@ var (
 	}
 	sampled128bitTraceID = opentracing.TextMapCarrier{
 		"x-b3-traceid": "463ac35c9f6413ad48485a3953bb6124",
-		"x-b3-spanid":  "0000000000000002",
+		"x-b3-spanid":  "2",
 		"x-b3-sampled": "1",
 	}
 	invalidTraceID = opentracing.TextMapCarrier{
 		"x-b3-traceid": "00000000000000000000000000000000",
-		"x-b3-spanid":  "0000000000000002",
+		"x-b3-spanid":  "2",
 		"x-b3-sampled": "1",
 	}
 )
@@ -156,7 +156,7 @@ func TestCustomBaggagePrefix(t *testing.T) {
 	err := propag.Inject(sc, hdr)
 	assert.Nil(t, err)
 	m := opentracing.TextMapCarrier{
-		"x-b3-traceid": "1",
+		"x-b3-traceid": "0000000000000001",
 		"x-b3-spanid":  "2",
 		"x-b3-sampled": "1",
 		"emoji:)foo":   "bar",


### PR DESCRIPTION
The wire encoding of the TraceID uses zero prefixes (#472).
The JaegerUI also uses zero prefixes (since 1.16).
So it makes sense that the Stringer of the TraceID also does this.

Resolves #532

Signed-off-by: Lukas Vogel <vogel@anapaya.net>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

