### PR TITLE
remove Infof call with no formatting directives

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -120,7 +120,7 @@ func DebugLogAdapter(logger Logger) DebugLogger {
 	if debugLogger, ok := logger.(DebugLogger); ok {
 		return debugLogger
 	}
-	logger.Infof("debug logging disabled")
+	logger.Info("debug logging disabled")
 	return debugDisabledLogAdapter{logger: logger}
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -30,6 +30,9 @@ type Logger interface {
 	Error(msg string)
 
 	// Infof logs a message at info priority
+	Info(msg string)
+
+	// Infof logs a message at info priority
 	Infof(msg string, args ...interface{})
 }
 
@@ -40,6 +43,11 @@ type stdLogger struct{}
 
 func (l *stdLogger) Error(msg string) {
 	log.Printf("ERROR: %s", msg)
+}
+
+// Infof logs a message at info priority
+func (l *stdLogger) Info(msg string) {
+	log.Printf(msg)
 }
 
 // Infof logs a message at info priority
@@ -58,6 +66,7 @@ var NullLogger = &nullLogger{}
 type nullLogger struct{}
 
 func (l *nullLogger) Error(msg string)                       {}
+func (l *nullLogger) Info(msg string)                        {}
 func (l *nullLogger) Infof(msg string, args ...interface{})  {}
 func (l *nullLogger) Debugf(msg string, args ...interface{}) {}
 
@@ -71,6 +80,13 @@ type BytesBufferLogger struct {
 func (l *BytesBufferLogger) Error(msg string) {
 	l.mux.Lock()
 	l.buf.WriteString(fmt.Sprintf("ERROR: %s\n", msg))
+	l.mux.Unlock()
+}
+
+// Info implements Logger.
+func (l *BytesBufferLogger) Info(msg string) {
+	l.mux.Lock()
+	l.buf.WriteString("INFO: " + msg + "\n")
 	l.mux.Unlock()
 }
 
@@ -130,6 +146,10 @@ type debugDisabledLogAdapter struct {
 
 func (d debugDisabledLogAdapter) Error(msg string) {
 	d.logger.Error(msg)
+}
+
+func (d debugDisabledLogAdapter) Info(msg string) {
+	d.logger.Info(msg)
 }
 
 func (d debugDisabledLogAdapter) Infof(msg string, args ...interface{}) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -47,7 +47,7 @@ func (l *stdLogger) Error(msg string) {
 
 // Info logs a message at info priority
 func (l *stdLogger) Info(msg string) {
-	log.Printf(msg)
+	log.Print(msg)
 }
 
 // Infof logs a message at info priority

--- a/log/logger.go
+++ b/log/logger.go
@@ -29,7 +29,7 @@ type Logger interface {
 	// Error logs a message at error priority
 	Error(msg string)
 
-	// Infof logs a message at info priority
+	// Info logs a message at info priority
 	Info(msg string)
 
 	// Infof logs a message at info priority
@@ -45,7 +45,7 @@ func (l *stdLogger) Error(msg string) {
 	log.Printf("ERROR: %s", msg)
 }
 
-// Infof logs a message at info priority
+// Info logs a message at info priority
 func (l *stdLogger) Info(msg string) {
 	log.Printf(msg)
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -85,6 +85,11 @@ func TestDebugLogAdapter_delegation(t *testing.T) {
 	assert.False(t, infoErrorLogger.infoCalled)
 	assert.False(t, infoErrorLogger.errorCalled)
 
+	adapted.Info("Frodo")
+	assert.True(t, infoErrorLogger.infoCalled)
+	assert.Equal(t, "Frodo", infoErrorLogger.msg)
+	infoErrorLogger.Reset()
+
 	adapted.Infof("Bodo", "Proudfoot")
 	assert.True(t, infoErrorLogger.infoCalled)
 	assert.Equal(t, "Bodo", infoErrorLogger.msg)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -24,10 +24,11 @@ func TestLogger(t *testing.T) {
 	bbLogger := &BytesBufferLogger{}
 	for _, logger := range []DebugLogger{StdLogger, NullLogger, bbLogger} {
 		logger.Infof("Hi %s", "there")
+		logger.Info("Big")
 		logger.Error("Bad wolf")
 		logger.Debugf("wolf")
 	}
-	assert.Equal(t, "INFO: Hi there\nERROR: Bad wolf\nDEBUG: wolf\n", bbLogger.String())
+	assert.Equal(t, "INFO: Hi there\nINFO: Big\nERROR: Bad wolf\nDEBUG: wolf\n", bbLogger.String())
 	bbLogger.Flush()
 	assert.Empty(t, bbLogger.String())
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -52,6 +52,11 @@ func (i *mockLogger) Error(msg string) {
 	i.msg = msg
 }
 
+func (i *mockLogger) Info(msg string) {
+	i.infoCalled = true
+	i.msg = msg
+}
+
 func (i *mockLogger) Infof(msg string, args ...interface{}) {
 	i.infoCalled = true
 	i.msg = msg

--- a/logger.go
+++ b/logger.go
@@ -27,6 +27,9 @@ type Logger interface {
 	Error(msg string)
 
 	// Infof logs a message at info priority
+	Info(msg string)
+
+	// Infof logs a message at info priority
 	Infof(msg string, args ...interface{})
 }
 
@@ -40,6 +43,11 @@ func (l *stdLogger) Error(msg string) {
 }
 
 // Infof logs a message at info priority
+func (l *stdLogger) Info(msg string) {
+	log.Printf(msg)
+}
+
+// Infof logs a message at info priority
 func (l *stdLogger) Infof(msg string, args ...interface{}) {
 	log.Printf(msg, args...)
 }
@@ -50,4 +58,5 @@ var NullLogger = &nullLogger{}
 type nullLogger struct{}
 
 func (l *nullLogger) Error(msg string)                      {}
+func (l *nullLogger) Info(msg string)                       {}
 func (l *nullLogger) Infof(msg string, args ...interface{}) {}

--- a/logger.go
+++ b/logger.go
@@ -26,7 +26,7 @@ type Logger interface {
 	// Error logs a message at error priority
 	Error(msg string)
 
-	// Infof logs a message at info priority
+	// Info logs a message at info priority
 	Info(msg string)
 
 	// Infof logs a message at info priority
@@ -42,7 +42,7 @@ func (l *stdLogger) Error(msg string) {
 	log.Printf("ERROR: %s", msg)
 }
 
-// Infof logs a message at info priority
+// Info logs a message at info priority
 func (l *stdLogger) Info(msg string) {
 	log.Printf(msg)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -23,6 +23,7 @@ import (
 func TestLogger(t *testing.T) {
 	for _, logger := range []Logger{StdLogger, NullLogger} {
 		logger.Infof("Hi %s", "there")
+		logger.Info("Big")
 		logger.Error("Bad wolf")
 	}
 }
@@ -30,11 +31,13 @@ func TestLogger(t *testing.T) {
 func TestCompatibility(t *testing.T) {
 	for _, logger := range []log.Logger{StdLogger, NullLogger} {
 		logger.Infof("Hi %s", "there")
+		logger.Info("Big")
 		logger.Error("Bad wolf")
 	}
 
 	for _, logger := range []Logger{log.StdLogger, log.NullLogger} {
 		logger.Infof("Hi %s", "there")
+		logger.Info("Big")
 		logger.Error("Bad wolf")
 	}
 }

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -118,6 +118,8 @@ func (r *recordingLogger) Error(msg string) {
 	r.errors = append(r.errors, msg)
 }
 
+func (r *recordingLogger) Info(msg string) {}
+
 func (r *recordingLogger) Infof(msg string, args ...interface{}) {}
 
 func TestHTTPErrorLogging(t *testing.T) {
@@ -144,7 +146,7 @@ func TestHTTPErrorLogging(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		logger := new(recordingLogger)
+		logger := &recordingLogger{}
 
 		sender, err := NewHTTPTransport(tc.URL)
 		require.NoError(t, err)


### PR DESCRIPTION
## Which problem is this PR solving?
- The log line caused `debug logging disabled%!(EXTRA []interface {}=[])` when starting the client.

## Short description of the changes
- This removes the formatting call, which was previously not used.
