### PR TITLE
Fix flags width in uber-trace-id header.

### DIFF
--- a/propagation_test.go
+++ b/propagation_test.go
@@ -128,7 +128,7 @@ func TestSpanPropagator(t *testing.T) {
 }
 
 func TestSpanIntegrityAfterSerialize(t *testing.T) {
-	serializedString := "f6c385a2c57ed8d7:00b04a90b7723bdc:76c385a2c57ed8d7:1"
+	serializedString := "f6c385a2c57ed8d7:00b04a90b7723bdc:76c385a2c57ed8d7:01"
 
 	context, err := ContextFromString(serializedString)
 	require.NoError(t, err)

--- a/span_context.go
+++ b/span_context.go
@@ -217,9 +217,9 @@ func (c SpanContext) String() string {
 		flags = c.samplingState.stateFlags.Load()
 	}
 	if c.traceID.High == 0 {
-		return fmt.Sprintf("%016x:%016x:%016x:%x", c.traceID.Low, uint64(c.spanID), uint64(c.parentID), flags)
+		return fmt.Sprintf("%016x:%016x:%016x:%02x", c.traceID.Low, uint64(c.spanID), uint64(c.parentID), flags)
 	}
-	return fmt.Sprintf("%016x%016x:%016x:%016x:%x", c.traceID.High, c.traceID.Low, uint64(c.spanID), uint64(c.parentID), flags)
+	return fmt.Sprintf("%016x%016x:%016x:%016x:%02x", c.traceID.High, c.traceID.Low, uint64(c.spanID), uint64(c.parentID), flags)
 }
 
 // ContextFromString reconstructs the Context encoded in a string

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -68,7 +68,7 @@ func TestContextFromString(t *testing.T) {
 	assert.Equal(t, "00000000000000ff", TraceID{Low: 255}.String())
 	assert.Equal(t, "00000000000000ff00000000000000ff", TraceID{High: 255, Low: 255}.String())
 	ctx = NewSpanContext(TraceID{High: 255, Low: 255}, SpanID(1), SpanID(1), false, nil)
-	assert.Equal(t, "00000000000000ff00000000000000ff:0000000000000001:0000000000000001:0", ctx.String())
+	assert.Equal(t, "00000000000000ff00000000000000ff:0000000000000001:0000000000000001:00", ctx.String())
 }
 
 func TestSpanContext_WithBaggageItem(t *testing.T) {


### PR DESCRIPTION
See https://github.com/jaegertracing/jaeger-client-go/issues/541.

Signed-off-by: Pavel Patrin <pavelpatrin@gmail.com>