### PR TITLE
Lock RemotelyControlledSampler.sampler on callbacks

### DIFF
--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -95,22 +95,30 @@ func (s *RemotelyControlledSampler) IsSampled(id TraceID, operation string) (boo
 
 // OnCreateSpan implements OnCreateSpan of SamplerV2.
 func (s *RemotelyControlledSampler) OnCreateSpan(span *Span) SamplingDecision {
-	return s.Sampler().OnCreateSpan(span)
+	s.RLock()
+	defer s.RUnlock()
+	return s.sampler.OnCreateSpan(span)
 }
 
 // OnSetOperationName implements OnSetOperationName of SamplerV2.
 func (s *RemotelyControlledSampler) OnSetOperationName(span *Span, operationName string) SamplingDecision {
-	return s.Sampler().OnSetOperationName(span, operationName)
+	s.RLock()
+	defer s.RUnlock()
+	return s.sampler.OnSetOperationName(span, operationName)
 }
 
 // OnSetTag implements OnSetTag of SamplerV2.
 func (s *RemotelyControlledSampler) OnSetTag(span *Span, key string, value interface{}) SamplingDecision {
-	return s.Sampler().OnSetTag(span, key, value)
+	s.RLock()
+	defer s.RUnlock()
+	return s.sampler.OnSetTag(span, key, value)
 }
 
 // OnFinishSpan implements OnFinishSpan of SamplerV2.
 func (s *RemotelyControlledSampler) OnFinishSpan(span *Span) SamplingDecision {
-	return s.Sampler().OnFinishSpan(span)
+	s.RLock()
+	defer s.RUnlock()
+	return s.sampler.OnFinishSpan(span)
 }
 
 // Close implements Close() of Sampler.
@@ -157,7 +165,6 @@ func (s *RemotelyControlledSampler) Sampler() SamplerV2 {
 	defer s.RUnlock()
 	return s.sampler
 }
-
 func (s *RemotelyControlledSampler) setSampler(sampler SamplerV2) {
 	s.Lock()
 	defer s.Unlock()


### PR DESCRIPTION
We've detected some race condition. In case you are using `RemotelyControlledSampler` it will call to Update method for sampler in it's background settings-polling routine. In the same time IsSampled (or any other exposed method of sampler) can be called from another goroutine and try to access sampler's data.

```
2020-10-06_09:52:19.35460 ==================
2020-10-06_09:52:19.35462 WARNING: DATA RACE
2020-10-06_09:52:19.35462 Write at 0x00c000073150 by goroutine 14:
2020-10-06_09:52:19.35463   github.com/uber/jaeger-client-go.(*ProbabilisticSampler).init()
2020-10-06_09:52:19.35463       /project/build/vendor/github.com/uber/jaeger-client-go/sampler.go:130 +0xe4
2020-10-06_09:52:19.35463   github.com/uber/jaeger-client-go.(*ProbabilisticSampler).Update()
2020-10-06_09:52:19.35463       /project/build/vendor/github.com/uber/jaeger-client-go/sampler.go:166 +0x104
2020-10-06_09:52:19.35464   github.com/uber/jaeger-client-go.(*ProbabilisticSamplerUpdater).Update()
2020-10-06_09:52:19.35464       /project/build/vendor/github.com/uber/jaeger-client-go/sampler_remote.go:225 +0xe4
2020-10-06_09:52:19.35464   github.com/uber/jaeger-client-go.(*RemotelyControlledSampler).updateSamplerViaUpdaters()
2020-10-06_09:52:19.35465       /project/build/vendor/github.com/uber/jaeger-client-go/sampler_remote.go:198 +0x129
2020-10-06_09:52:19.35465   github.com/uber/jaeger-client-go.(*RemotelyControlledSampler).UpdateSampler()
2020-10-06_09:52:19.35465       /project/build/vendor/github.com/uber/jaeger-client-go/sampler_remote.go:187 +0x59b
2020-10-06_09:52:19.35465   github.com/uber/jaeger-client-go.(*RemotelyControlledSampler).pollControllerWithTicker()
2020-10-06_09:52:19.35466       /project/build/vendor/github.com/uber/jaeger-client-go/sampler_remote.go:146 +0x57
2020-10-06_09:52:19.35466   github.com/uber/jaeger-client-go.(*RemotelyControlledSampler).pollController()
2020-10-06_09:52:19.35467       /project/build/vendor/github.com/uber/jaeger-client-go/sampler_remote.go:139 +0xa4
2020-10-06_09:52:19.35467 
2020-10-06_09:52:19.35467 Previous read at 0x00c000073150 by goroutine 713:
2020-10-06_09:52:19.35467   github.com/uber/jaeger-client-go.(*ProbabilisticSampler).IsSampled()
2020-10-06_09:52:19.35468       /project/build/vendor/github.com/uber/jaeger-client-go/sampler.go:145 +0x50
2020-10-06_09:52:19.35468   github.com/uber/jaeger-client-go.(*ProbabilisticSampler).IsSampled-fm()
2020-10-06_09:52:19.35468       /project/build/vendor/github.com/uber/jaeger-client-go/sampler.go:144 +0x26
2020-10-06_09:52:19.35469   github.com/uber/jaeger-client-go.(*legacySamplerV1Base).OnCreateSpan()
2020-10-06_09:52:19.35469       /project/build/vendor/github.com/uber/jaeger-client-go/sampler_v2.go:76 +0xd2
2020-10-06_09:52:19.35470   github.com/uber/jaeger-client-go.(*ProbabilisticSampler).OnCreateSpan()
```

Signed-off-by: Dima Kozlov <hummerd@mail.ru>