### PR TITLE
Additional context protections

### DIFF
--- a/span.go
+++ b/span.go
@@ -475,13 +475,13 @@ func (s SpanContext) isSamplingFinalized() bool {
 // setSamplingPriority returns true if the flag was updated successfully, false otherwise.
 // The behavior of setSamplingPriority is surprising
 // If noDebugFlagOnForcedSampling is set
-//     setSamplingPriority(span, 1) always sets only flagSampled
+//     setSamplingPriority(..., 1) always sets only flagSampled
 // If noDebugFlagOnForcedSampling is unset, and isDebugAllowed passes
-//     setSamplingPriority(span, 1) sets both flagSampled and flagDebug
+//     setSamplingPriority(..., 1) sets both flagSampled and flagDebug
 // However,
-//     setSamplingPriority(span, 0) always only resets flagSampled
+//     setSamplingPriority(..., 0) always only resets flagSampled
 //
-// This means that doing a setSamplingPriority(span, 1) followed by setSamplingPriority(span, 0) can
+// This means that doing a setSamplingPriority(..., 1) followed by setSamplingPriority(..., 0) can
 // leave flagDebug set
 func setSamplingPriority(state *samplingState, operationName string, tracer *Tracer, value interface{}) bool {
 	val, ok := value.(uint16)

--- a/span.go
+++ b/span.go
@@ -462,16 +462,6 @@ func (s *Span) applySamplingDecision(decision SamplingDecision, lock bool) {
 	}
 }
 
-// Span can be written to if it is sampled or the sampling decision has not been finalized.
-func (s SpanContext) isWriteable() bool {
-	state := s.samplingState
-	return !state.isFinal() || state.isSampled()
-}
-
-func (s SpanContext) isSamplingFinalized() bool {
-	return s.samplingState.isFinal()
-}
-
 // setSamplingPriority returns true if the flag was updated successfully, false otherwise.
 // The behavior of setSamplingPriority is surprising
 // If noDebugFlagOnForcedSampling is set

--- a/span.go
+++ b/span.go
@@ -85,8 +85,9 @@ func NewTag(key string, value interface{}) Tag {
 func (s *Span) SetOperationName(operationName string) opentracing.Span {
 	s.Lock()
 	s.operationName = operationName
+	ctx := s.context
 	s.Unlock()
-	if !s.isSamplingFinalized() {
+	if !ctx.isSamplingFinalized() {
 		decision := s.tracer.sampler.OnSetOperationName(s, operationName)
 		s.applySamplingDecision(decision, true)
 	}
@@ -100,15 +101,22 @@ func (s *Span) SetTag(key string, value interface{}) opentracing.Span {
 }
 
 func (s *Span) setTagInternal(key string, value interface{}, lock bool) opentracing.Span {
+	var ctx SpanContext
+	if lock {
+		ctx = s.SpanContext()
+	} else {
+		ctx = s.context
+	}
+
 	s.observer.OnSetTag(key, value)
-	if key == string(ext.SamplingPriority) && !setSamplingPriority(s, value) {
+	if key == string(ext.SamplingPriority) && !setSamplingPriority(s, ctx, value) {
 		return s
 	}
-	if !s.isSamplingFinalized() {
+	if !ctx.isSamplingFinalized() {
 		decision := s.tracer.sampler.OnSetTag(s, key, value)
 		s.applySamplingDecision(decision, lock)
 	}
-	if s.isWriteable() {
+	if ctx.isWriteable() {
 		if lock {
 			s.Lock()
 			defer s.Unlock()
@@ -340,12 +348,13 @@ func (s *Span) FinishWithOptions(options opentracing.FinishOptions) {
 	s.observer.OnFinish(options)
 	s.Lock()
 	s.duration = options.FinishTime.Sub(s.startTime)
+	ctx := s.context
 	s.Unlock()
-	if !s.isSamplingFinalized() {
+	if !ctx.isSamplingFinalized() {
 		decision := s.tracer.sampler.OnFinishSpan(s)
 		s.applySamplingDecision(decision, true)
 	}
-	if s.context.IsSampled() {
+	if ctx.IsSampled() {
 		s.Lock()
 		s.fixLogsIfDropped()
 		if len(options.LogRecords) > 0 || len(options.BulkLogData) > 0 {
@@ -426,11 +435,18 @@ func (s *Span) serviceName() string {
 }
 
 func (s *Span) applySamplingDecision(decision SamplingDecision, lock bool) {
+	var ctx SpanContext
+	if lock {
+		ctx = s.SpanContext()
+	} else {
+		ctx = s.context
+	}
+
 	if !decision.Retryable {
-		s.context.samplingState.setFinal()
+		ctx.samplingState.setFinal()
 	}
 	if decision.Sample {
-		s.context.samplingState.setSampled()
+		ctx.samplingState.setSampled()
 		if len(decision.Tags) > 0 {
 			if lock {
 				s.Lock()
@@ -444,13 +460,13 @@ func (s *Span) applySamplingDecision(decision SamplingDecision, lock bool) {
 }
 
 // Span can be written to if it is sampled or the sampling decision has not been finalized.
-func (s *Span) isWriteable() bool {
-	state := s.context.samplingState
+func (s SpanContext) isWriteable() bool {
+	state := s.samplingState
 	return !state.isFinal() || state.isSampled()
 }
 
-func (s *Span) isSamplingFinalized() bool {
-	return s.context.samplingState.isFinal()
+func (s SpanContext) isSamplingFinalized() bool {
+	return s.samplingState.isFinal()
 }
 
 // setSamplingPriority returns true if the flag was updated successfully, false otherwise.
@@ -464,23 +480,23 @@ func (s *Span) isSamplingFinalized() bool {
 //
 // This means that doing a setSamplingPriority(span, 1) followed by setSamplingPriority(span, 0) can
 // leave flagDebug set
-func setSamplingPriority(s *Span, value interface{}) bool {
+func setSamplingPriority(s *Span, ctx SpanContext, value interface{}) bool {
 	val, ok := value.(uint16)
 	if !ok {
 		return false
 	}
 	if val == 0 {
-		s.context.samplingState.unsetSampled()
-		s.context.samplingState.setFinal()
+		ctx.samplingState.unsetSampled()
+		ctx.samplingState.setFinal()
 		return true
 	}
 	if s.tracer.options.noDebugFlagOnForcedSampling {
-		s.context.samplingState.setSampled()
-		s.context.samplingState.setFinal()
+		ctx.samplingState.setSampled()
+		ctx.samplingState.setFinal()
 		return true
 	} else if s.tracer.isDebugAllowed(s.operationName) {
-		s.context.samplingState.setDebugAndSampled()
-		s.context.samplingState.setFinal()
+		ctx.samplingState.setDebugAndSampled()
+		ctx.samplingState.setFinal()
 		return true
 	}
 	return false

--- a/span_context.go
+++ b/span_context.go
@@ -271,6 +271,16 @@ func (c SpanContext) Flags() byte {
 	return c.samplingState.flags()
 }
 
+// Span can be written to if it is sampled or the sampling decision has not been finalized.
+func (c SpanContext) isWriteable() bool {
+	state := c.samplingState
+	return !state.isFinal() || state.isSampled()
+}
+
+func (c SpanContext) isSamplingFinalized() bool {
+	return c.samplingState.isFinal()
+}
+
 // NewSpanContext creates a new instance of SpanContext
 func NewSpanContext(traceID TraceID, spanID, parentID SpanID, sampled bool, baggage map[string]string) SpanContext {
 	samplingState := &samplingState{}

--- a/span_test.go
+++ b/span_test.go
@@ -363,7 +363,6 @@ func TestSpan_References(t *testing.T) {
 }
 
 func TestSpanContextRaces(t *testing.T) {
-	t.Skip("Skipped: test will panic with -race, see https://github.com/jaegertracing/jaeger-client-go/issues/526")
 	tracer, closer := NewTracer("test", NewConstSampler(true), NewNullReporter())
 	defer closer.Close()
 
@@ -394,6 +393,15 @@ func TestSpanContextRaces(t *testing.T) {
 	})
 	go accessor(func() {
 		span.BaggageItem("k")
+	})
+	go accessor(func() {
+		ext.SamplingPriority.Set(span, 0)
+	})
+	go accessor(func() {
+		EnableFirehose(span)
+	})
+	go accessor(func() {
+		span.SpanContext().samplingState.setFlag(flagDebug)
 	})
 	time.Sleep(100 * time.Millisecond)
 	close(end)

--- a/span_test.go
+++ b/span_test.go
@@ -406,6 +406,9 @@ func TestSpanContextRaces(t *testing.T) {
 	go accessor(func() {
 		span.SetOperationName("test")
 	})
+	go accessor(func() {
+		span.FinishWithOptions(opentracing.FinishOptions{})
+	})
 	time.Sleep(100 * time.Millisecond)
 	close(end)
 }

--- a/span_test.go
+++ b/span_test.go
@@ -403,6 +403,9 @@ func TestSpanContextRaces(t *testing.T) {
 	go accessor(func() {
 		span.SpanContext().samplingState.setFlag(flagDebug)
 	})
+	go accessor(func() {
+		span.SetOperationName("test")
+	})
 	time.Sleep(100 * time.Millisecond)
 	close(end)
 }

--- a/tracer.go
+++ b/tracer.go
@@ -320,7 +320,7 @@ func (t *Tracer) startSpanWithOptions(
 	sp.references = references
 	sp.firstInProcess = rpcServer || sp.context.parentID == 0
 
-	if !sp.isSamplingFinalized() {
+	if !sp.context.isSamplingFinalized() {
 		decision := t.sampler.OnCreateSpan(sp)
 		sp.applySamplingDecision(decision, false)
 	}
@@ -413,7 +413,7 @@ func (t *Tracer) newSpan() *Span {
 // calling client-side span, but obviously the server side span is
 // no longer a root span of the trace.
 func (t *Tracer) emitNewSpanMetrics(sp *Span, newTrace bool) {
-	if !sp.isSamplingFinalized() {
+	if !sp.context.isSamplingFinalized() {
 		t.metrics.SpansStartedDelayedSampling.Inc(1)
 		if newTrace {
 			t.metrics.TracesStartedDelayedSampling.Inc(1)
@@ -437,7 +437,7 @@ func (t *Tracer) emitNewSpanMetrics(sp *Span, newTrace bool) {
 }
 
 func (t *Tracer) reportSpan(sp *Span) {
-	if !sp.isSamplingFinalized() {
+	if !sp.context.isSamplingFinalized() {
 		t.metrics.SpansFinishedDelayedSampling.Inc(1)
 	} else if sp.context.IsSampled() {
 		t.metrics.SpansFinishedSampled.Inc(1)

--- a/tracer.go
+++ b/tracer.go
@@ -437,9 +437,11 @@ func (t *Tracer) emitNewSpanMetrics(sp *Span, newTrace bool) {
 }
 
 func (t *Tracer) reportSpan(sp *Span) {
-	if !sp.context.isSamplingFinalized() {
+	ctx := sp.SpanContext()
+
+	if !ctx.isSamplingFinalized() {
 		t.metrics.SpansFinishedDelayedSampling.Inc(1)
-	} else if sp.context.IsSampled() {
+	} else if ctx.IsSampled() {
 		t.metrics.SpansFinishedSampled.Inc(1)
 	} else {
 		t.metrics.SpansFinishedNotSampled.Inc(1)
@@ -448,7 +450,7 @@ func (t *Tracer) reportSpan(sp *Span) {
 	// Note: if the reporter is processing Span asynchronously then it needs to Retain() the span,
 	// and then Release() it when no longer needed.
 	// Otherwise, the span may be reused for another trace and its data may be overwritten.
-	if sp.context.IsSampled() {
+	if ctx.IsSampled() {
 		t.reporter.Report(sp)
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #526 

## Short description of the changes
- Made `isWriteable()` and `isSamplingFinalized()` methods on SpanContext
- Changed `setTagInternal()` and `applySamplingDecision()` to retrieve the context appropriately under lock or not
- Changed `setSamplingPriority()` to take a `*samplingState` and other required params
- Reenabled and extended `TestSpanContextRaces()`

## Benchmarks

**branch**
```
goos: linux
goarch: amd64
pkg: github.com/uber/jaeger-client-go
BenchmarkTracer/sampler=NeverSample/remoteSampler=false/children=false/tags=5/ops=10/cpus-8         	 4943131	       245 ns/op
BenchmarkTracer/sampler=NeverSample/remoteSampler=false/children=true/tags=5/ops=10/cpus-8          	 3944086	       348 ns/op
BenchmarkTracer/sampler=AlwaysSample/remoteSampler=false/children=false/tags=5/ops=10/cpus-8        	 3023574	       400 ns/op
BenchmarkTracer/sampler=AlwaysSample/remoteSampler=false/children=true/tags=5/ops=10/cpus-8         	 2553519	       472 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleNoLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8         	 1532324	       730 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleNoLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8          	 3645086	       337 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleNoLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8        	  805288	      1443 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleNoLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8         	 1786104	       727 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleWithLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8       	  650238	      1788 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleWithLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8        	  619460	      1840 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleWithLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8      	  594268	      1816 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleWithLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8       	  561058	      1903 ns/op
PASS
```

**master**
```
goos: linux
goarch: amd64
pkg: github.com/uber/jaeger-client-go
BenchmarkTracer/sampler=NeverSample/remoteSampler=false/children=false/tags=5/ops=10/cpus-8         	 6046756	       203 ns/op
BenchmarkTracer/sampler=NeverSample/remoteSampler=false/children=true/tags=5/ops=10/cpus-8          	 4618400	       261 ns/op
BenchmarkTracer/sampler=AlwaysSample/remoteSampler=false/children=false/tags=5/ops=10/cpus-8        	 3357320	       361 ns/op
BenchmarkTracer/sampler=AlwaysSample/remoteSampler=false/children=true/tags=5/ops=10/cpus-8         	 2852832	       422 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleNoLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8         	 1490359	       861 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleNoLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8          	 4337530	       283 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleNoLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8        	 1000000	      1064 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleNoLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8         	 1964678	       662 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleWithLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8       	  753090	      1496 ns/op
BenchmarkTracer/sampler=AdaptiveNeverSampleWithLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8        	  763476	      1584 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleWithLateBinding/remoteSampler=false/children=false/tags=5/ops=10/cpus-8      	  735798	      1544 ns/op
BenchmarkTracer/sampler=AdaptiveAlwaysSampleWithLateBinding/remoteSampler=false/children=true/tags=5/ops=10/cpus-8       	  674318	      1606 ns/op
PASS
```