### PR TITLE
Simplify GOPATH settings in GH actions

### DIFF
--- a/.github/actions/setup-gopath/action.yml
+++ b/.github/actions/setup-gopath/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         export GOPATH=$(go env GOPATH)
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
+        export PROJECT=$GOPATH/src/github.com/uber/jaeger-client-go
         mkdir -p $(dirname $PROJECT)
         ln -s $(pwd) $PROJECT
         # write to GH files to make vars available to later steps

--- a/.github/actions/setup-gopath/action.yml
+++ b/.github/actions/setup-gopath/action.yml
@@ -1,0 +1,16 @@
+name: 'Setup GOPATH'
+description: 'Link repo into GOPATH and export $PROJECT var'
+runs:
+  using: "composite"
+  steps: 
+    - name: Setup GOPATH
+    - run: |
+        export GOPATH=$(go env GOPATH)
+        echo "GOPATH=$GOPATH"
+        export PROJECT=$GOPATH/src/${{env.PROJECT}}
+        mkdir -p $(dirname $PROJECT)
+        ln -s $(pwd) $PROJECT
+        # write to GH files to make vars available to later steps
+        echo "PROJECT=$PROJECT" >>"$GITHUB_ENV"
+        echo "GOPATH=$GOPATH" >>"$GITHUB_ENV"
+        echo "$GOPATH/bin" >>"$GITHUB_PATH"

--- a/.github/actions/setup-gopath/action.yml
+++ b/.github/actions/setup-gopath/action.yml
@@ -4,9 +4,9 @@ runs:
   using: "composite"
   steps: 
     - name: Setup GOPATH
-    - run: |
+      shell: bash
+      run: |
         export GOPATH=$(go env GOPATH)
-        echo "GOPATH=$GOPATH"
         export PROJECT=$GOPATH/src/${{env.PROJECT}}
         mkdir -p $(dirname $PROJECT)
         ln -s $(pwd) $PROJECT
@@ -14,3 +14,6 @@ runs:
         echo "PROJECT=$PROJECT" >>"$GITHUB_ENV"
         echo "GOPATH=$GOPATH" >>"$GITHUB_ENV"
         echo "$GOPATH/bin" >>"$GITHUB_PATH"
+        # print summary 
+        echo "GOPATH=$GOPATH"
+        echo "PROJECT=$PROJECT"

--- a/.github/workflows/crossdoc-integration-test.yml
+++ b/.github/workflows/crossdoc-integration-test.yml
@@ -11,39 +11,25 @@ jobs:
     strategy:
       fail-fast: true
     runs-on: ubuntu-latest
-    env:
-      PROJECT: github.com/uber/jaeger-client-go
-
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ^1.15
-
-    - name: Install dependencies and tools
-      run: |
-        export GOPATH=$HOME/go
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
-        mkdir -p $GOPATH
-        export PATH=$PATH:$(go env GOPATH)/bin
-        mkdir -p $(dirname $PROJECT)
-        ln -s $(pwd) $PROJECT
-        cd $PROJECT
-        make install-ci USE_DEP=true
-        dep version
-        docker-compose version
-
-    - name: Run tests
-      run: |
-        export GOPATH=$HOME/go
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
-        cd $PROJECT
-        make crossdock
-
-    - name: Dump docker-compose logs
-      if: ${{ failure() }}
-      run: |
-        make crossdock-logs
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - name: Setup GOPATH
+        uses: ./.github/actions/setup-gopath
+      - name: Install dependencies and tools
+        run: |
+          cd $PROJECT
+          make install-ci USE_DEP=true
+          docker-compose version
+      - name: Run tests
+        run: |
+          cd $PROJECT
+          make crossdock
+      - name: Dump docker-compose logs
+        if: ${{ failure() }}
+        run: |
+          make crossdock-logs
 
 # TODO publish crossdock image to Docher Hub

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,14 +13,14 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.14.x"
-      # Runs a set of commands to initialize and analyze with FOSSA
+      - name: Setup GOPATH
+        uses: ./.github/actions/setup-gopath
       - name: run FOSSA analysis
         env:
           # FOSSA Push-Only API Token
           FOSSA_API_KEY: '304657e2357ba57b416b94e6b119131b'
         run: |
-          export GOPATH=$HOME/go
-          export PATH=$PATH:$(go env GOPATH)/bin
+          cd $PROJECT
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
           fossa init
           fossa analyze

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         go-version: ^1.15
 
-    - uses: .github/actions/setup-gopath
+    - uses: ./.github/actions/setup-gopath
 
     - name: Setup GOPATH
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         go-version: ^1.15
 
-    - uses: ./github/actions/setup-gopath
+    - uses: .github/actions/setup-gopath
 
     - name: Setup GOPATH
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,86 +11,46 @@ jobs:
     strategy:
       fail-fast: true
     runs-on: ubuntu-latest
-    env:
-      PROJECT: github.com/uber/jaeger-client-go
-
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ^1.15
-
-    - name: Setup GOPATH
-      uses: ./.github/actions/setup-gopath
-
-    # - name: Check GOPATH
-    #   run: |
-    #     echo "GOPATH=$GOPATH"
-    #     echo "PROJECT=$PROJECT"
-
-    # - name: Setup GOPATH
-    #   run: |
-    #     export GOPATH=$(go env GOPATH)
-    #     echo "GOPATH=$GOPATH"
-    #     export PROJECT=$GOPATH/src/${{env.PROJECT}}
-    #     mkdir -p $(dirname $PROJECT)
-    #     ln -s $(pwd) $PROJECT
-    #     # write to GH files to make vars available to later steps
-    #     echo "PROJECT=$PROJECT" >>"$GITHUB_ENV"
-    #     echo "GOPATH=$GOPATH" >>"$GITHUB_ENV"
-    #     echo "$GOPATH/bin" >>"$GITHUB_PATH"
-
-    - name: Install dependencies and tools
-      run: |
-        cd $PROJECT
-        pwd
-        make install-ci USE_DEP=true
-        dep version
-
-    - name: Run tests
-      run: |
-        cd $PROJECT
-        pwd
-        make test-ci
-
-    - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: cover.out
-        fail_ci_if_error: true
-        verbose: true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - name: Setup GOPATH
+        uses: ./.github/actions/setup-gopath
+      - name: Install dependencies and tools
+        run: |
+          cd $PROJECT
+          make install-ci USE_DEP=true
+          dep version
+      - name: Run tests
+        run: |
+          cd $PROJECT
+          make test-ci
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: cover.out
+          fail_ci_if_error: true
+          verbose: true
 
   unit-tests-glide:
     strategy:
       fail-fast: true
     runs-on: ubuntu-latest
-    env:
-      PROJECT: github.com/uber/jaeger-client-go
-
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ^1.15
-
-    - name: Install dependencies and tools
-      run: |
-        export GOPATH=$HOME/go
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
-        mkdir -p $GOPATH
-        export PATH=$PATH:$(go env GOPATH)/bin
-        mkdir -p $(dirname $PROJECT)
-        ln -s $(pwd) $PROJECT
-        cd $PROJECT
-        make install-ci USE_DEP=false USE_GLIDE=true
-        glide -v
-
-    - name: Run tests
-      run: |
-        export GOPATH=$HOME/go
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
-        export PATH=$PATH:$(go env GOPATH)/bin
-        cd $PROJECT
-        make test-ci
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - name: Setup GOPATH
+        uses: ./.github/actions/setup-gopath
+      - name: Install dependencies and tools
+        run: |
+          cd $PROJECT
+          make install-ci USE_DEP=false USE_GLIDE=true
+          glide -v
+      - name: Run tests
+        run: |
+          cd $PROJECT
+          make test-ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,25 +23,26 @@ jobs:
 
     - name: Setup GOPATH
       run: |
-        echo "GOPATH=$(go env GOPATH)"
+        export GOPATH=$(go env GOPATH)
+        echo "GOPATH=$GOPATH"
+        export PROJECT=$GOPATH/src/${{env.PROJECT}}
+        mkdir -p $(dirname $PROJECT)
+        ln -s $(pwd) $PROJECT
+        # write to GH files to make vars available to later steps
+        echo "PROJECT=$PROJECT" >>"$GITHUB_ENV"
+        echo "GOPATH=$GOPATH" >>"$GITHUB_ENV"
+        echo "$GOPATH/bin" >>"$GITHUB_PATH"
 
     - name: Install dependencies and tools
       run: |
-        export GOPATH=$HOME/go
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
-        mkdir -p $GOPATH
-        export PATH=$PATH:$(go env GOPATH)/bin
-        mkdir -p $(dirname $PROJECT)
-        ln -s $(pwd) $PROJECT
+        # cd $GOPATH/src/${{env.PROJECT}}
         cd $PROJECT
         make install-ci USE_DEP=true
         dep version
 
     - name: Run tests
       run: |
-        export GOPATH=$HOME/go
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
-        export PATH=$PATH:$(go env GOPATH)/bin
+        # cd $GOPATH/src/${{env.PROJECT}}
         cd $PROJECT
         make test-ci
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         go-version: ^1.15
 
+    - uses: ./github/actions/setup-gopath
+
     - name: Setup GOPATH
       run: |
         export GOPATH=$(go env GOPATH)

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,10 @@ jobs:
       with:
         go-version: ^1.15
 
+    - name: Setup GOPATH
+      run: |
+        echo "GOPATH=$(go env GOPATH)"
+
     - name: Install dependencies and tools
       run: |
         export GOPATH=$HOME/go

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,6 +23,11 @@ jobs:
 
     - uses: ./.github/actions/setup-gopath
 
+    - name: Check GOPATH
+      run: |
+        echo "GOPATH=$GOPATH"
+        echo "PROJECT=$PROJECT"
+
     - name: Setup GOPATH
       run: |
         export GOPATH=$(go env GOPATH)

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,36 +21,37 @@ jobs:
       with:
         go-version: ^1.15
 
-    - uses: ./.github/actions/setup-gopath
-
-    - name: Check GOPATH
-      run: |
-        echo "GOPATH=$GOPATH"
-        echo "PROJECT=$PROJECT"
-
     - name: Setup GOPATH
-      run: |
-        export GOPATH=$(go env GOPATH)
-        echo "GOPATH=$GOPATH"
-        export PROJECT=$GOPATH/src/${{env.PROJECT}}
-        mkdir -p $(dirname $PROJECT)
-        ln -s $(pwd) $PROJECT
-        # write to GH files to make vars available to later steps
-        echo "PROJECT=$PROJECT" >>"$GITHUB_ENV"
-        echo "GOPATH=$GOPATH" >>"$GITHUB_ENV"
-        echo "$GOPATH/bin" >>"$GITHUB_PATH"
+      uses: ./.github/actions/setup-gopath
+
+    # - name: Check GOPATH
+    #   run: |
+    #     echo "GOPATH=$GOPATH"
+    #     echo "PROJECT=$PROJECT"
+
+    # - name: Setup GOPATH
+    #   run: |
+    #     export GOPATH=$(go env GOPATH)
+    #     echo "GOPATH=$GOPATH"
+    #     export PROJECT=$GOPATH/src/${{env.PROJECT}}
+    #     mkdir -p $(dirname $PROJECT)
+    #     ln -s $(pwd) $PROJECT
+    #     # write to GH files to make vars available to later steps
+    #     echo "PROJECT=$PROJECT" >>"$GITHUB_ENV"
+    #     echo "GOPATH=$GOPATH" >>"$GITHUB_ENV"
+    #     echo "$GOPATH/bin" >>"$GITHUB_PATH"
 
     - name: Install dependencies and tools
       run: |
-        # cd $GOPATH/src/${{env.PROJECT}}
         cd $PROJECT
+        pwd
         make install-ci USE_DEP=true
         dep version
 
     - name: Run tests
       run: |
-        # cd $GOPATH/src/${{env.PROJECT}}
         cd $PROJECT
+        pwd
         make test-ci
 
     - name: Upload coverage to codecov


### PR DESCRIPTION
* Add local `setup-gopath` github action and reuse it in other workflows
  * it writes to `$GITHUB_ENV` file to expose new env vars to subsequent steps
  * it creates a symlink `$GOPATH/src/github.com/uber/jaeger-client-go` and exports it as `$PROJECT` var
* other workflows run this action and the only need to do `cd $PROJECT` before running Go commands
* fixed the GOPATH issue for #551, but FOSSA fails for other reasons now