### PR TITLE
feat: extend configuration to support custom randomNumber func

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -277,6 +277,10 @@ func (c Configuration) NewTracer(options ...Option) (opentracing.Tracer, io.Clos
 		tracerOptions = append(tracerOptions, jaeger.TracerOptions.Gen128Bit(true))
 	}
 
+	if opts.randomNumber != nil {
+		tracerOptions = append(tracerOptions, jaeger.TracerOptions.RandomNumber(opts.randomNumber))
+	}
+
 	for _, tag := range opts.tags {
 		tracerOptions = append(tracerOptions, jaeger.TracerOptions.Tag(tag.Key, tag.Value))
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -912,6 +912,6 @@ func TestWithRandomNumber(t *testing.T) {
 	spanCtx := span.Context().(jaeger.SpanContext)
 
 	assert.NoError(t, err)
-	assert.Equal(t, spanCtx.TraceID().Low, traceID)
+	assert.Equal(t, traceID, spanCtx.TraceID().Low)
 	defer closeCloser(t, closer)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -905,7 +905,7 @@ func TestWithRandomNumber(t *testing.T) {
 		ServiceName: "test-random-number",
 	}
 	randomNum := func() uint64 { return 1 }
-	_, closer, err := cfg.NewTracer(WithRandomNunmber(randomNum))
+	_, closer, err := cfg.NewTracer(WithRandomNumber(randomNum))
 	assert.NoError(t, err)
 	defer closeCloser(t, closer)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -899,3 +899,13 @@ func TestThrottlerDefaultConfig(t *testing.T) {
 	assert.NoError(t, err)
 	defer closeCloser(t, closer)
 }
+
+func TestWithRandomNumber(t *testing.T) {
+	cfg := &Configuration{
+		ServiceName: "test-random-number",
+	}
+	randomNum := func() uint64 { return 1 }
+	_, closer, err := cfg.NewTracer(WithRandomNunmber(randomNum))
+	assert.NoError(t, err)
+	defer closeCloser(t, closer)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -908,10 +908,10 @@ func TestWithRandomNumber(t *testing.T) {
 	}
 	randomNum := func() uint64 { return traceID }
 	tracer, closer, err := cfg.NewTracer(WithRandomNumber(randomNum))
-	span:=tracer.StartSpan("test-span")
+	span := tracer.StartSpan("test-span")
 	spanCtx := span.Context().(jaeger.SpanContext)
 
 	assert.NoError(t, err)
-	assert.Equal(t, spanCtx.TraceID().Low ,traceID)
+	assert.Equal(t, spanCtx.TraceID().Low, traceID)
 	defer closeCloser(t, closer)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -901,11 +901,17 @@ func TestThrottlerDefaultConfig(t *testing.T) {
 }
 
 func TestWithRandomNumber(t *testing.T) {
+	const traceID uint64 = 1
+
 	cfg := &Configuration{
 		ServiceName: "test-random-number",
 	}
-	randomNum := func() uint64 { return 1 }
-	_, closer, err := cfg.NewTracer(WithRandomNumber(randomNum))
+	randomNum := func() uint64 { return traceID }
+	tracer, closer, err := cfg.NewTracer(WithRandomNumber(randomNum))
+	span:=tracer.StartSpan("test-span")
+	spanCtx := span.Context().(jaeger.SpanContext)
+
 	assert.NoError(t, err)
+	assert.Equal(t, spanCtx.TraceID().Low ,traceID)
 	defer closeCloser(t, closer)
 }

--- a/config/options.go
+++ b/config/options.go
@@ -148,8 +148,8 @@ func Extractor(format interface{}, extractor jaeger.Extractor) Option {
 	}
 }
 
-// WithRandonNunmber set the Tracer random number func
-func WithRandonNunmber(f func() uint64) Option {
+// WithRandomNunmber set the Tracer random number func
+func WithRandomNunmber(f func() uint64) Option {
 	return func(c *Options) {
 		c.randomNumber = f
 	}

--- a/config/options.go
+++ b/config/options.go
@@ -148,7 +148,7 @@ func Extractor(format interface{}, extractor jaeger.Extractor) Option {
 	}
 }
 
-// WithRandomNumber set the Tracer random number func
+// WithRandomNumber supplies a random number generator function to the Tracer used to generate trace and span IDs.
 func WithRandomNumber(f func() uint64) Option {
 	return func(c *Options) {
 		c.randomNumber = f

--- a/config/options.go
+++ b/config/options.go
@@ -148,8 +148,8 @@ func Extractor(format interface{}, extractor jaeger.Extractor) Option {
 	}
 }
 
-// WithRandomNunmber set the Tracer random number func
-func WithRandomNunmber(f func() uint64) Option {
+// WithRandomNumber set the Tracer random number func
+func WithRandomNumber(f func() uint64) Option {
 	return func(c *Options) {
 		c.randomNumber = f
 	}

--- a/config/options.go
+++ b/config/options.go
@@ -40,6 +40,7 @@ type Options struct {
 	tags                        []opentracing.Tag
 	injectors                   map[interface{}]jaeger.Injector
 	extractors                  map[interface{}]jaeger.Extractor
+	randomNumber                func() uint64
 }
 
 // Metrics creates an Option that initializes Metrics in the tracer,
@@ -144,6 +145,13 @@ func Injector(format interface{}, injector jaeger.Injector) Option {
 func Extractor(format interface{}, extractor jaeger.Extractor) Option {
 	return func(c *Options) {
 		c.extractors[format] = extractor
+	}
+}
+
+// WithRandonNunmber set the Tracer random number func
+func WithRandonNunmber(f func() uint64) Option {
+	return func(c *Options) {
+		c.randomNumber = f
 	}
 }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- I want set tracer randomNumber when the config.New() called

## Short description of the changes
- Added the WithRandomNumber function and the randomNumber field for config.Options. Finally, apply the setting in the config.NewTracer() function
