### PR TITLE
Add support for configuring static sampling strategies via file

### DIFF
--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -297,6 +297,14 @@ func (u *AdaptiveSamplerUpdater) Update(sampler SamplerV2, strategy interface{})
 
 // -----------------------
 
+type fileSamplingStrategyFetcher struct {
+	strategiesFile string
+}
+
+func (f *fileSamplingStrategyFetcher) Fetch(serviceName string) ([]byte, error) {
+	return ioutil.ReadFile(f.strategiesFile)
+}
+
 type httpSamplingStrategyFetcher struct {
 	serverURL string
 	logger    log.DebugLogger


### PR DESCRIPTION
Closes #491

Adds support for https://www.jaegertracing.io/docs/1.17/sampling/#collector-sampling-configuration

I'm opening this now while I test this with an actual application reading the file from disk, but I wanted to open it for feedback, or in case someone else wants to steward the change in the event that I get busy!