### PR TITLE
Trim baggage key when parsing

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -292,7 +292,7 @@ func (p *TextMapPropagator) parseCommaSeparatedMap(value string) map[string]stri
 	for _, kvpair := range strings.Split(value, ",") {
 		kv := strings.Split(strings.TrimSpace(kvpair), "=")
 		if len(kv) == 2 {
-			baggage[kv[0]] = kv[1]
+			baggage[strings.TrimSpace(kv[0])] = kv[1]
 		} else {
 			log.Printf("Malformed value passed in for %s", p.headerKeys.JaegerBaggageHeader)
 		}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -257,6 +257,7 @@ func TestParseCommaSeperatedMap(t *testing.T) {
 		{"malformed", map[string]string{}},
 		{"malformed, string", map[string]string{}},
 		{"another malformed string", map[string]string{}},
+		{"key2=value2,    key3    =    value3   ", map[string]string{"key2": "value2", "key3": "    value3"}},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
Signed-off-by: lastchiliarch <lastchiliarch@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Trim  baggage key in parseCommaSeparatedMap，see  #271 

## Short description of the changes
-  Trim baggage key when parseing