### PR TITLE
Use exponential backoff for pollController

### DIFF
--- a/ticker.go
+++ b/ticker.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"math/rand"
+	"time"
+)
+
+var random *rand.Rand
+
+func init() {
+	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// Ticker  is a customer Ticker, it perform like a normal time.Ticker when operation is success,
+// When Operation is fail, it will use exponential backoff with a jitter.
+type Ticker struct {
+	C        <-chan time.Time
+	timer    *time.Timer
+	duration time.Duration
+	failCnt  uint
+}
+
+// NewTicker construct a new Ticker
+func NewTicker(duratin time.Duration) *Ticker {
+	t := &Ticker{
+		timer:    time.NewTimer(duratin),
+		duration: duratin,
+	}
+	t.C = t.timer.C
+	return t
+}
+
+// Stop turns off a Ticker. After Stop, no more ticks will be sent.
+func (t *Ticker) Stop() {
+	t.timer.Stop()
+}
+
+// UpdateTimer update the timer use operation result, must be called after every operation
+func (t *Ticker) UpdateTimer(err error) {
+	d := t.next(err)
+	t.timer.Reset(d)
+	t.C = t.timer.C
+}
+
+func (t *Ticker) next(err error) time.Duration {
+	if err == nil {
+		t.failCnt = 0
+		return t.duration
+	}
+	t.failCnt++
+	return jitterBackOff(t.duration, t.failCnt-1)
+}
+
+//MaxInterval max duration for the timer
+const MaxInterval = time.Minute * 5
+
+// jitterBackOff returns ever increasing backoffs by a power of 2 util reach the maxInterval
+// with +/- 0-33% to prevent sychronized reuqests.
+func jitterBackOff(duration time.Duration, i uint) time.Duration {
+	backoff := jitter(duration, 1<<i)
+	if backoff > MaxInterval {
+		return MaxInterval
+	}
+	return backoff
+}
+
+// jitter keeps the +/- 0-33% logic in one place
+func jitter(duration time.Duration, i uint) time.Duration {
+	interval := int64(duration) * int64(i)
+	//return time.Duration(interval)
+	delta := interval / 3
+	if delta <= 0 {
+		return time.Duration(interval)
+	}
+	// interval ± rand
+	interval += random.Int63n(2*delta) - delta
+	// a jitter of 0 messes up the time.Tick chan
+	if interval <= 0 {
+		interval = 1
+	}
+	return time.Duration(interval)
+}

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestJitterBackOff(t *testing.T) {
+	type args struct {
+		duration time.Duration
+		i        uint
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Duration
+	}{
+		{
+			"jitterBackOff-second-0",
+			args{time.Second, 0},
+			time.Second,
+		},
+		{
+			"jitterBackOff-milliseconds-100",
+			args{time.Millisecond * 100, 0},
+			time.Millisecond * 100,
+		},
+		{
+			"jitterBackOff-milliseconds-0",
+			args{time.Millisecond * 500, 0},
+			time.Millisecond * 500,
+		},
+		{
+			"jitterBackOff-milliseconds-1",
+			args{time.Millisecond * 500, 1},
+			time.Second,
+		},
+		{
+			"jitterBackOff-milliseconds-2",
+			args{time.Millisecond * 500, 2},
+			time.Second * 2,
+		},
+		{
+			"jitterBackOff-minute-0",
+			args{time.Minute, 0},
+			time.Minute,
+		},
+		{
+			"jitterBackOff-max",
+			args{time.Second, 10},
+			MaxInterval,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := jitterBackOff(tt.args.duration, tt.args.i)
+			assert.True(t, assert.InDelta(t, got, tt.want, float64(tt.want)*1.0/3, "timer not excatlt"))
+		})
+	}
+}
+
+func TestTickerOpertionSuccess(t *testing.T) {
+	count := 5
+	delta := time.Millisecond * 20
+	operation := func() error {
+		return nil
+	}
+	t0 := time.Now()
+	ticker := NewTicker(delta)
+	for j := 0; j < count; j++ {
+		<-ticker.C
+		err := operation()
+		ticker.UpdateTimer(err)
+	}
+	ticker.Stop()
+	t1 := time.Now()
+	dt := t1.Sub(t0)
+	target := delta * time.Duration(count)
+	slop := target * 5 / 10
+	if dt < target-slop || dt > target+slop {
+		t.Errorf("ticks took %s, expected [%s,%s]", delta, target-slop, target+slop)
+	}
+}
+
+func TestTickerOpertionFail(t *testing.T) {
+	count := 5
+	delta := time.Millisecond * 20
+	operation := func() error {
+		return fmt.Errorf("operation fail")
+	}
+	t0 := time.Now()
+	ticker := NewTicker(delta)
+	//backoff cnt
+	backCnt := 1 + 2 + 4 + 8
+	for j := 0; j < count; j++ {
+		<-ticker.C
+		err := operation()
+		ticker.UpdateTimer(err)
+	}
+	ticker.Stop()
+	t1 := time.Now()
+	dt := t1.Sub(t0)
+	target := delta * time.Duration(backCnt)
+	slop := target * 5 / 10
+	if dt < target-slop || dt > target+slop {
+		t.Errorf("ticks took %s, expected [%s,%s]", dt, target-slop, target+slop)
+	}
+}
+
+func TestTickerOpertionNormal(t *testing.T) {
+	count := 7
+	delta := time.Millisecond * 20
+	operation := func(i int) error {
+		if i <= 1 {
+			return nil
+		}
+		if i <= 4 {
+			return fmt.Errorf("operation fail")
+		}
+		return nil
+	}
+	t0 := time.Now()
+	ticker := NewTicker(delta)
+	//first two success,  then third error, end with two success operation
+	backCnt := 1 + 1 + 1 + 2 + 4 + 1 + 1
+	for j := 0; j < count; j++ {
+		<-ticker.C
+		err := operation(j)
+		ticker.UpdateTimer(err)
+	}
+	ticker.Stop()
+	t1 := time.Now()
+	dt := t1.Sub(t0)
+	target := delta * time.Duration(backCnt)
+	slop := target * 5 / 10
+	if dt < target-slop || dt > target+slop {
+		t.Errorf("ticks took %s, expected [%s,%s]", dt, target-slop, target+slop)
+	}
+}


### PR DESCRIPTION
* introduce github.com/cenkalti/backoff
* replace time.Ticker with  backoff.Ticker

Signed-off-by: lastchiliarch <lastchiliarch@163.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  Use exponential backoff for pollController, see #392 

## Short description of the changes
-  introduce github.com/cenkalti/backoff
-  replace time.Ticker with  backoff.Ticker
