### PR TITLE
Release 2.26.0 - Update JaegerClientVersion

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// JaegerClientVersion is the version of the client library reported as Span tag.
-	JaegerClientVersion = "Go-2.25.1-dev"
+	JaegerClientVersion = "Go-2.26.0"
 
 	// JaegerClientVersionTagKey is the name of the tag used to report client version.
 	JaegerClientVersionTagKey = "jaeger.version"


### PR DESCRIPTION
## Which problem is this PR solving?
- Correct JaegerClientVersion in constants.go for 2.26.0
