### PR TITLE
HTTPSamplingStrategyFetcher: Use http client with 10 second timeout

### DIFF
--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	defaultRemoteSamplingTimeout   = 10 * time.Second
 	defaultSamplingRefreshInterval = time.Minute
 )
 
@@ -298,8 +299,22 @@ func (u *AdaptiveSamplerUpdater) Update(sampler SamplerV2, strategy interface{})
 // -----------------------
 
 type httpSamplingStrategyFetcher struct {
-	serverURL string
-	logger    log.DebugLogger
+	serverURL  string
+	logger     log.DebugLogger
+	httpClient http.Client
+}
+
+func newHTTPSamplingStrategyFetcher(serverUrl string, logger log.DebugLogger) *httpSamplingStrategyFetcher {
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.ResponseHeaderTimeout = defaultRemoteSamplingTimeout
+
+	return &httpSamplingStrategyFetcher{
+		serverURL: serverUrl,
+		logger:    logger,
+		httpClient: http.Client{
+			Transport: customTransport,
+		},
+	}
 }
 
 func (f *httpSamplingStrategyFetcher) Fetch(serviceName string) ([]byte, error) {
@@ -307,8 +322,7 @@ func (f *httpSamplingStrategyFetcher) Fetch(serviceName string) ([]byte, error) 
 	v.Set("service", serviceName)
 	uri := f.serverURL + "?" + v.Encode()
 
-	// TODO create and reuse http.Client with proper timeout settings, etc.
-	resp, err := http.Get(uri)
+	resp, err := f.httpClient.Get(uri)
 	if err != nil {
 		return nil, err
 	}

--- a/sampler_remote.go
+++ b/sampler_remote.go
@@ -304,12 +304,12 @@ type httpSamplingStrategyFetcher struct {
 	httpClient http.Client
 }
 
-func newHTTPSamplingStrategyFetcher(serverUrl string, logger log.DebugLogger) *httpSamplingStrategyFetcher {
+func newHTTPSamplingStrategyFetcher(serverURL string, logger log.DebugLogger) *httpSamplingStrategyFetcher {
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	customTransport.ResponseHeaderTimeout = defaultRemoteSamplingTimeout
 
 	return &httpSamplingStrategyFetcher{
-		serverURL: serverUrl,
+		serverURL: serverURL,
 		logger:    logger,
 		httpClient: http.Client{
 			Transport: customTransport,

--- a/sampler_remote_options.go
+++ b/sampler_remote_options.go
@@ -140,10 +140,7 @@ func (o *samplerOptions) applyOptionsAndDefaults(opts ...SamplerOption) *sampler
 		o.samplingRefreshInterval = defaultSamplingRefreshInterval
 	}
 	if o.samplingFetcher == nil {
-		o.samplingFetcher = &httpSamplingStrategyFetcher{
-			serverURL: o.samplingServerURL,
-			logger:    o.logger,
-		}
+		o.samplingFetcher = newHTTPSamplingStrategyFetcher(o.samplingServerURL, o.logger)
 	}
 	if o.samplingParser == nil {
 		o.samplingParser = new(samplingStrategyParser)


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #577

## Short description of the changes
- Use an `http.Client` with response timeout set to `10s` instead of the default of 0.
