### PR TITLE
Encode SpanID and ParentSpanID as a 16 hex characters in zipkin propagator

### DIFF
--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -61,9 +61,9 @@ func (p Propagator) Inject(
 
 	textMapWriter.Set("x-b3-traceid", sc.TraceID().String())
 	if sc.ParentID() != 0 {
-		textMapWriter.Set("x-b3-parentspanid", strconv.FormatUint(uint64(sc.ParentID()), 16))
+		textMapWriter.Set("x-b3-parentspanid", sc.ParentID().String())
 	}
-	textMapWriter.Set("x-b3-spanid", strconv.FormatUint(uint64(sc.SpanID()), 16))
+	textMapWriter.Set("x-b3-spanid", sc.SpanID().String())
 	if sc.IsSampled() {
 		textMapWriter.Set("x-b3-sampled", "1")
 	} else {

--- a/zipkin/propagation_test.go
+++ b/zipkin/propagation_test.go
@@ -33,31 +33,31 @@ var (
 var (
 	rootSampledHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid": "0000000000000001",
-		"x-b3-spanid":  "2",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "1",
 		"baggage-foo":  "bar",
 	}
 	nonRootSampledHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid":      "0000000000000001",
-		"x-b3-spanid":       "2",
-		"x-b3-parentspanid": "1",
+		"x-b3-spanid":       "0000000000000002",
+		"x-b3-parentspanid": "0000000000000001",
 		"x-b3-sampled":      "1",
 	}
 	nonRootNonSampledHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid":      "0000000000000001",
-		"x-b3-spanid":       "2",
-		"x-b3-parentspanid": "1",
+		"x-b3-spanid":       "0000000000000002",
+		"x-b3-parentspanid": "0000000000000001",
 		"x-b3-sampled":      "0",
 	}
 	rootSampledBooleanHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid": "0000000000000001",
-		"x-b3-spanid":  "2",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "true",
 		"baggage-foo":  "bar",
 	}
 	nonRootSampledBooleanHeader = opentracing.TextMapCarrier{
 		"x-b3-traceid":      "0000000000000001",
-		"x-b3-spanid":       "2",
+		"x-b3-spanid":       "0000000000000002",
 		"x-b3-parentspanid": "1",
 		"x-b3-sampled":      "true",
 	}
@@ -69,12 +69,12 @@ var (
 	}
 	sampled128bitTraceID = opentracing.TextMapCarrier{
 		"x-b3-traceid": "463ac35c9f6413ad48485a3953bb6124",
-		"x-b3-spanid":  "2",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "1",
 	}
 	invalidTraceID = opentracing.TextMapCarrier{
 		"x-b3-traceid": "00000000000000000000000000000000",
-		"x-b3-spanid":  "2",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "1",
 	}
 )
@@ -157,7 +157,7 @@ func TestCustomBaggagePrefix(t *testing.T) {
 	assert.Nil(t, err)
 	m := opentracing.TextMapCarrier{
 		"x-b3-traceid": "0000000000000001",
-		"x-b3-spanid":  "2",
+		"x-b3-spanid":  "0000000000000002",
 		"x-b3-sampled": "1",
 		"emoji:)foo":   "bar",
 	}


### PR DESCRIPTION
Based on the [openzipkin/b3-propagation](https://github.com/openzipkin/b3-propagation#spanid-1) specification, the SpanID and
ParentSpanID are to be encoded as 16 lower-hex characters.

https://github.com/jaegertracing/jaeger-client-go/pull/533 fixed this for TraceID, and fixed the SpanID.String() method, but did not update the Zipkin Propagator to use the fixed SpanID encoding.

This fix uses SpanID.String() to ensure proper encoding of the SpanID and ParentSpanID within the Zipkin Propagator.

Signed-off-by: Nathan Bowler <nzb301@psu.edu>

