### PR TITLE
Remove redundant newline in NewReporter init message

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -420,7 +420,7 @@ func (rc *ReporterConfig) NewReporter(
 		jaeger.ReporterOptions.Logger(logger),
 		jaeger.ReporterOptions.Metrics(metrics))
 	if rc.LogSpans && logger != nil {
-		logger.Infof("Initializing logging reporter\n")
+		logger.Infof("Initializing logging reporter")
 		reporter = jaeger.NewCompositeReporter(jaeger.NewLoggingReporter(logger), reporter)
 	}
 	return reporter, err


### PR DESCRIPTION
It's calling logger.Infof, but loggers already include a trailing
newline where it's needed, so don't include our own.

Signed-off-by: Wade Carpenter <wwade@users.noreply.github.com>

## Short description of the changes
- Remove redundant newline in NewReporter init message
