### PR TITLE
Fix missing sampler tags in generated root span when startSpan

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -326,10 +326,7 @@ func (t *Tracer) startSpanWithOptions(
 	}
 	sp.observer = t.observer.OnStartSpan(sp, operationName, options)
 
-	if tagsTotalLength := len(options.Tags) + len(internalTags); tagsTotalLength > 0 {
-		if sp.tags == nil || cap(sp.tags) < tagsTotalLength {
-			sp.tags = make([]Tag, 0, tagsTotalLength)
-		}
+	if len(options.Tags)+len(internalTags) > 0 {
 		sp.tags = append(sp.tags, internalTags...)
 		for k, v := range options.Tags {
 			sp.setTagInternal(k, v, false)


### PR DESCRIPTION
Signed-off-by: Chen Xu <chen.x@uber.com>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  Resolves #611

## Short description of the changes
- Remove the code to create a new slice to sp.tags
- Update and add unit tests to verify

## Additional explanation
I understand the `jaeger-client-go` is deprecated, and no new PR request is accepted. 
I just need to create a public PR (not need to merge), then I can patch in our own internal repo following our process.
