### PR TITLE
Fix bug of zero credit in rate limiter

### DIFF
--- a/utils/rate_limiter.go
+++ b/utils/rate_limiter.go
@@ -21,7 +21,7 @@ import (
 
 // RateLimiter is a filter used to check if a message that is worth itemCost units is within the rate limits.
 //
-// TODO (breaking change) remove this interface in favor of public struct below
+// # TODO (breaking change) remove this interface in favor of public struct below
 //
 // Deprecated, use ReconfigurableRateLimiter.
 type RateLimiter interface {
@@ -55,9 +55,13 @@ type ReconfigurableRateLimiter struct {
 
 // NewRateLimiter creates a new ReconfigurableRateLimiter.
 func NewRateLimiter(creditsPerSecond, maxBalance float64) *ReconfigurableRateLimiter {
+	balance := maxBalance
+	if creditsPerSecond == 0 {
+		balance = 0
+	}
 	return &ReconfigurableRateLimiter{
 		creditsPerSecond: creditsPerSecond,
-		balance:          maxBalance,
+		balance:          balance,
 		maxBalance:       maxBalance,
 		lastTick:         time.Now(),
 		timeNow:          time.Now,

--- a/utils/rate_limiter_test.go
+++ b/utils/rate_limiter_test.go
@@ -73,6 +73,22 @@ func TestRateLimiterMaxBalance(t *testing.T) {
 	assert.False(t, rl.CheckCredit(1.0))
 }
 
+func TestRateLimiterZeroCreditsPerSecond(t *testing.T) {
+	rl := NewRateLimiter(0, 1.0)
+	// stop time
+	ts := time.Now()
+	rl.lastTick = ts
+	rl.timeNow = func() time.Time {
+		return ts
+	}
+	assert.False(t, rl.CheckCredit(1.0), "on initialization, should not have any credit for 1 message")
+
+	rl.timeNow = func() time.Time {
+		return ts.Add(time.Second * 20)
+	}
+	assert.False(t, rl.CheckCredit(1.0))
+}
+
 func TestRateLimiterReconfigure(t *testing.T) {
 	rl := NewRateLimiter(1, 1.0)
 	assertBalance := func(expected float64) {


### PR DESCRIPTION
## Which problem is this PR solving?
Fix the bug that zero credit per second can still grand credit for the first request.

## Short description of the changes
- 

## Additional explanation
I understand the jaeger-client-go is deprecated, and no new PR request is accepted.
I have to create a public PR (not need to merge) in order to patch in our own internal repo following our process.
